### PR TITLE
fixes for Julia 0.4 syntax changes

### DIFF
--- a/src/Elly.jl
+++ b/src/Elly.jl
@@ -8,7 +8,7 @@ using CRC
 import Base: connect, readdir, show, isfile, isdir, islink, stat, filesize, filemode, mtime, mkdir, 
         mv, rm, abspath, cd, pwd, touch, open, nb_available, cp,
         eof, position, seek, seekend, seekstart, skip, read, write, read!, readbytes, readall, close,
-        launch, manage
+        launch, manage, convert
 import ProtoBuf: write_bytes, read_bytes, call_method
 import URIParser: URI
 

--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -65,18 +65,21 @@ end
 function HDFSFile(uristr::AbstractString)
     uri = URI(uristr)
     (uri.schema == "hdfs") || throw(HDFSException("Not a HDFS URI: $uristr"))
-    client = HDFSClient(uri.host, uri.port, uri.userinfo)
-    HDFSFile(client, u.path)
+    client = HDFSClient(uri.host, uri.port, UserGroupInformation(uri.userinfo))
+    HDFSFile(client, uri.path)
 end
 
 function show(io::IO, file::HDFSFile)
+    println(io, "HDFSFile: ", string(convert(URI, file)))
+    nothing
+end
+
+function convert(::Type{URI}, file::HDFSFile)
     client = file.client
     ch = client.nn_conn.channel
     user = username(ch.ugi)
     user_spec = isempty(user) ? user : "$(user)@"
-
-    println(io, "HDFSFile: hdfs://$(user_spec)$(ch.host):$(ch.port)$(abspath(client, file.path))")
-    nothing
+    URI("hdfs://$(user_spec)$(ch.host):$(ch.port)$(abspath(client, file.path))")
 end
 
 @doc doc"""

--- a/src/api_yarn_base.jl
+++ b/src/api_yarn_base.jl
@@ -170,7 +170,7 @@ function get_connection(nodes::YarnNodes, nodeid::NodeIdProto)
     node.isrunning || throw(YarnException("Yarn node $(nodeid.host):$(nodeid.port) is not running"))
 
     t = time()
-    if nodeid in nodes.conn
+    if nodeid in keys(nodes.conn)
         (conn,lastusetime) = nodes.conn[nodeid]
         (t < (lastusetime + nodes.keepalivesecs)) && (return conn)
         try


### PR DESCRIPTION
Syntax fixes related to Julia 0.4 changes.

Was causing (reported at http://stackoverflow.com/questions/31827047/copying-a-file-to-hdfs-using-julia-language):

```
julia> cp("/etc/hosts",hostsFile)
ERROR: Associative collections only contain Pairs;
Either look for e.g. A=>B instead, or use the `keys` or `values`
function if you are looking for a key or value respectively.
in in at dict.jl:13
in _get at /home/bala/.julia/v0.4/Elly/src/rpc.jl:371
in call at /home/bala/.julia/v0.4/Elly/src/rpc.jl:786
in _write at /home/bala/.julia/v0.4/Elly/src/api_hdfs_io.jl:293
in write at /home/bala/.julia/v0.4/Elly/src/api_hdfs_io.jl:311
in cp at /home/bala/.julia/v0.4/Elly/src/api_hdfs_io.jl:376
```
