### PR TITLE
retry on encountering stale data node connections

### DIFF
--- a/src/Elly.jl
+++ b/src/Elly.jl
@@ -34,8 +34,13 @@ export YarnManager, launch, manage
 #using Logging
 #const logger = Logging.configure(level=DEBUG)
 #const logger = Logging.configure(filename="/tmp/elly$(getpid()).log", level=DEBUG)
-#logmsg(s) = debug(s)
-#logmsg(s) = nothing
+#macro logmsg(s)
+#    quote
+#        debug($(esc(s)))
+#    end
+#end
+macro logmsg(s)
+end
 
 include("hadoop/hadoop.jl")
 using Elly.hadoop

--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -386,7 +386,7 @@ function _complete_file(client::HDFSClient, path::AbstractString, last::Nullable
                 :clientName => ELLY_CLIENTNAME))
     if !isnull(last)
         set_field!(endinp, :last, get(last))
-        #logmsg("setting last block as $(get(last))")
+        @logmsg("setting last block as $(get(last))")
     end
 
     endresp = complete(client.nn_conn, endinp)
@@ -395,7 +395,7 @@ end
 
 function _add_block(client::HDFSClient, path::AbstractString, previous::Nullable{LocatedBlockProto}=Nullable{LocatedBlockProto}())
     isnull(previous) && (return _add_block(client, path))
-    #logmsg("adding next block to $(get(previous).b)")
+    @logmsg("adding next block to $(get(previous).b)")
     _add_block(client, path, Nullable(get(previous).b))
 end
 function _add_block(client::HDFSClient, path::AbstractString, previous::Nullable{ExtendedBlockProto}=Nullable{ExtendedBlockProto}())

--- a/src/api_yarn_base.jl
+++ b/src/api_yarn_base.jl
@@ -273,21 +273,21 @@ function update(containers::YarnContainers, arp::AllocateResponseProto)
             id = cont.id
             contlist[id] = cont
             push!(active, id)
-            #logmsg("calling callback for alloc")
+            @logmsg("calling callback for alloc")
             isnull(cballoc) || @async(get(cballoc)(id))
             #isnull(cballoc) || get(cballoc)(id)
         end
     end
     if isfilled(arp, :completed_container_statuses)
-        #logmsg("have completed containers")
+        @logmsg("have completed containers")
         for contst in arp.completed_container_statuses
             id = contst.container_id
-            #logmsg("container $id is finished")
+            @logmsg("container $id is finished")
             status[id] = contst
-            #logmsg("id in active: $(id in active)")
+            @logmsg("id in active: $(id in active)")
             (id in active) && pop!(active, id)
             (id in busy) && pop!(busy, id)
-            #logmsg("calling callback for finish")
+            @logmsg("calling callback for finish")
             isnull(cbfinish) || @async(get(cbfinish)(id))
             #isnull(cbfinish) || get(cbfinish)(id)
         end

--- a/src/api_yarn_client.jl
+++ b/src/api_yarn_client.jl
@@ -203,7 +203,7 @@ function status(app::YarnApp, refresh::Bool=true)
 end
 
 function wait_for_state(app::YarnApp, state::Int32, timeout_secs::Int=60)
-    #logmsg("waiting for application to reach $(APP_STATES[state]) ($state) state")
+    @logmsg("waiting for application to reach $(APP_STATES[state]) ($state) state")
     t1 = time() + timeout_secs
     finalstates = (YarnApplicationStateProto.KILLED, YarnApplicationStateProto.FAILED, YarnApplicationStateProto.FINISHED)
     isfinalstate = state in finalstates
@@ -243,7 +243,7 @@ function attempts(app::YarnApp, refresh::Bool=true)
 end
 
 function wait_for_attempt_state(app::YarnApp, attemptid::Int32, state::Int32, timeout_secs::Int=60)
-    #logmsg("waiting for application attempt $attemptid to reach $(ATTEMPT_STATES[state]) ($state) state")
+    @logmsg("waiting for application attempt $attemptid to reach $(ATTEMPT_STATES[state]) ($state) state")
     t1 = time() + timeout_secs
     finalstates = (YarnApplicationAttemptStateProto.APP_ATTEMPT_KILLED, YarnApplicationAttemptStateProto.APP_ATTEMPT_FAILED, YarnApplicationAttemptStateProto.APP_ATTEMPT_FINISHED)
     isfinalstate = state in finalstates
@@ -255,7 +255,7 @@ function wait_for_attempt_state(app::YarnApp, attemptid::Int32, state::Int32, ti
                 atmptstate = report.yarn_application_attempt_state
                 (atmptstate == state) && (return true)
                 isfinalstate || ((atmptstate in finalstates) && (return false))
-                #logmsg("application attempt $attemptid is in state $(ATTEMPT_STATES[atmptstate]) ($atmptstate) state")
+                @logmsg("application attempt $attemptid is in state $(ATTEMPT_STATES[atmptstate]) ($atmptstate) state")
                 break
             end
         end

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -13,7 +13,7 @@ immutable YarnManager <: ClusterManager
             params[n] = v
         end
         paramkeys = keys(params)
-        #logmsg("YarnManager constructor: params: $params")
+        @logmsg("YarnManager constructor: params: $params")
         
         user            = (:user            in paramkeys) ? params[:user]           : ""
         rmport          = (:rmport          in paramkeys) ? params[:rmport]         : 8032
@@ -41,7 +41,7 @@ function show(io::IO, yarncm::YarnManager)
 end
 
 function setup_worker(host, port)
-    #logmsg("YarnManager setup_worker: host:$host port:$port for container $(ENV[CONTAINER_ID])")
+    @logmsg("YarnManager setup_worker: host:$host port:$port for container $(ENV[CONTAINER_ID])")
     c = connect(IPv4(host), port)
     Base.wait_connected(c)
     redirect_stdout(c)
@@ -84,7 +84,7 @@ function _currprocname()
 end
 
 function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Condition)
-    #logmsg("YarnManager launch: params: $params")
+    @logmsg("YarnManager launch: params: $params")
 
     paramkeys   = keys(params)
     np          = (:np       in paramkeys)  ? params[:np]               : 1
@@ -107,8 +107,8 @@ function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Con
     initargs = "using Elly; Elly.setup_worker($(getipaddr().host), $(port))"
     clc = launchcontext(cmd="$cmd -e '$initargs'", env=appenv)
 
-    #logmsg("YarnManager launch: initargs: $initargs")
-    #logmsg("YarnManager launch: context: $clc")
+    @logmsg("YarnManager launch: initargs: $initargs")
+    @logmsg("YarnManager launch: context: $clc")
     on_alloc = (cid) -> container_start(manager.am, cid, clc)
     callback(manager.am, Nullable(on_alloc), Nullable{Function}())
 
@@ -147,7 +147,7 @@ end
 function manage(manager::YarnManager, id::Integer, config::WorkerConfig, op::Symbol)
     # This function needs to exist, but so far we don't do anything
     if op == :deregister
-        #logmsg("YarnManager manage: id:$id, op:$op, nprocs:$(nprocs())")
+        @logmsg("YarnManager manage: id:$id, op:$op, nprocs:$(nprocs())")
         !manager.keep_connected && (1 == nprocs()) && (@async disconnect(manager))
     end
     nothing

--- a/src/rpc.jl
+++ b/src/rpc.jl
@@ -65,8 +65,8 @@ function buffer_size_delimited(channelbuff::IOBuffer, obj)
 
     data = takebuf_array(iob)
     len = write_bytes(channelbuff, data)
-    #logmsg("$(typeof(obj)) -> $data")
-    #logmsg("$(typeof(obj)) -> buffer. len $len")
+    @logmsg("$(typeof(obj)) -> $data")
+    @logmsg("$(typeof(obj)) -> buffer. len $len")
     len
 end
 
@@ -78,14 +78,14 @@ function send_buffered(buff::IOBuffer, sock::TCPSocket, delimited::Bool)
         len = write(sock, hton(datalen))
     end
     len += write(sock, data)
-    #logmsg("buffer -> sock. len $len")
+    @logmsg("buffer -> sock. len $len")
     len
 end
 
 function recv_blockop(sock::TCPSocket)
-    #logmsg("recv block read message")
+    @logmsg("recv block read message")
     data_bytes = read_bytes(sock)
-    #logmsg("block_resp <- sock. len $(length(data_bytes))")
+    @logmsg("block_resp <- sock. len $(length(data_bytes))")
 
     block_resp = BlockOpResponseProto()
     readproto(IOBuffer(data_bytes), block_resp)
@@ -184,7 +184,7 @@ end
 # Connect to the hadoop server and complete the handshake
 function connect(channel::HadoopRpcChannel)
     # open connection
-    #logmsg("connecting to HadoopRpcChannel $(channel.host):$(channel.port)")
+    @logmsg("connecting to HadoopRpcChannel $(channel.host):$(channel.port)")
     try
         sock = connect(channel.host, channel.port)
         channel.sock = Nullable{TCPSocket}(sock)
@@ -201,10 +201,10 @@ function connect(channel::HadoopRpcChannel)
         buffer_conctx_reqhdr(channel)
         buffer_connctx(channel)
         send_buffered(channel, true)
-        #logmsg("connected to HadoopRpcChannel $(channel.host):$(channel.port)")
+        @logmsg("connected to HadoopRpcChannel $(channel.host):$(channel.port)")
         channel.call_id = HRPC_CALL_ID_NORMAL
     catch ex
-        #logmsg("exception connecting to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception connecting to $(channel.host):$(channel.port): $ex")
         disconnect(channel)
         rethrow(ex)
     end
@@ -217,7 +217,7 @@ function disconnect(channel::HadoopRpcChannel)
     try
         isconnected(channel) && close(get(channel.sock))
     catch ex
-        #logmsg("exception while closing channel socket $ex")
+        @logmsg("exception while closing channel socket $ex")
     end
     channel.sock = Nullable{TCPSocket}()
     channel.call_id = HRPC_CALL_ID_CONNCTX
@@ -228,14 +228,14 @@ function send_rpc_message(channel::HadoopRpcChannel, controller::HadoopRpcContro
     isconnected(channel) || connect(channel)
 
     try
-        #logmsg("send rpc message. method: $(method.name)")
+        @logmsg("send rpc message. method: $(method.name)")
         begin_send(channel)
         buffer_rpc_reqhdr(channel)
         buffer_method_reqhdr(channel, method)
         buffer_size_delimited(channel.iob, params)
         send_buffered(channel, true)
     catch ex
-        #logmsg("exception sending to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception sending to $(channel.host):$(channel.port): $ex")
         disconnect(channel)
         rethrow(ex)
     end
@@ -244,10 +244,10 @@ end
 
 function recv_rpc_message(channel::HadoopRpcChannel, resp)
     try
-        #logmsg("recv rpc message")
+        @logmsg("recv rpc message")
         msg_len = ntoh(read(get(channel.sock), UInt32))
         hdr_bytes = read_bytes(get(channel.sock))
-        #logmsg("hdr <- sock. len $(length(hdr_bytes))")
+        @logmsg("hdr <- sock. len $(length(hdr_bytes))")
 
         resp_hdr = RpcResponseHeaderProto()
         readproto(IOBuffer(hdr_bytes), resp_hdr)
@@ -260,14 +260,14 @@ function recv_rpc_message(channel::HadoopRpcChannel, resp)
             hdr_len += _len_uleb(hdr_len)
             if msg_len > hdr_len
                 data_bytes = read_bytes(get(channel.sock))
-                #logmsg("data <- sock. len $(length(data_bytes))")
+                @logmsg("data <- sock. len $(length(data_bytes))")
                 data_len = msg_len - hdr_len - _len_uleb(length(data_bytes))
                 (length(data_bytes) == data_len) || throw(HadoopRpcException("unexpected response data length. expected:$(data_len) read:$(length(data_bytes))"))
                 readproto(IOBuffer(data_bytes), resp)
             end
         end
     catch ex
-        #logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
         disconnect(channel)
         rethrow(ex)
     end
@@ -275,7 +275,7 @@ function recv_rpc_message(channel::HadoopRpcChannel, resp)
 end
 
 function call_method(channel::HadoopRpcChannel, method::MethodDescriptor, controller::HadoopRpcController, params)
-    #logmsg("call_method $(method.name)")
+    @logmsg("call_method $(method.name)")
     send_rpc_message(channel, controller, method, params)
     resp_type = get_response_type(method)
     resp = resp_type()
@@ -311,15 +311,15 @@ type HadoopDataChannel
 end
 
 function connect(channel::HadoopDataChannel)
-    #logmsg("connecting to HadoopDataChannel $(channel.host):$(channel.port)")
+    @logmsg("connecting to HadoopDataChannel $(channel.host):$(channel.port)")
     try
         sock = connect(channel.host, channel.port)
         channel.sock = Nullable(sock)
     catch ex
-        #logmsg("exception connecting to HadoopDataChannel $(channel.host):$(channel.port): $ex")
+        @logmsg("exception connecting to HadoopDataChannel $(channel.host):$(channel.port): $ex")
         rethrow(ex)
     end
-    #logmsg("connected to HadoopDataChannel $(channel.host):$(channel.port)")
+    @logmsg("connected to HadoopDataChannel $(channel.host):$(channel.port)")
     nothing
 end
 
@@ -327,7 +327,7 @@ function disconnect(channel::HadoopDataChannel)
     try
         isconnected(channel) && close(get(channel.sock))
     catch ex
-        #logmsg("exception while closing HadoopDataChannel socket $ex")
+        @logmsg("exception while closing HadoopDataChannel socket $ex")
     end
     channel.sock = Nullable{TCPSocket}()
     nothing
@@ -430,7 +430,7 @@ type HDFSBlockReader
 
     function HDFSBlockReader(host::AbstractString, port::Integer, block::LocatedBlockProto, offset::UInt64, len::UInt64, chk_crc::Bool)
         channel = _get(_dcpool, host, port)
-        #logmsg("creating block reader for offset $offset at $host:$port for length $len")
+        @logmsg("creating block reader for offset $offset at $host:$port for length $len")
         new(channel, block, offset, len,
             Nullable{BlockOpResponseProto}(), 0,
             Nullable{PacketHeaderProto}(), 0, 0,
@@ -475,7 +475,7 @@ function buffer_readblock(reader::HDFSBlockReader)
     basehdr = protobuild(BaseHeaderProto, @compat Dict(:block => exblock, :token => token))
     hdr = protobuild(ClientOperationHeaderProto, @compat Dict(:baseHeader => basehdr, :clientName => ELLY_CLIENTNAME))
     readblock = protobuild(OpReadBlockProto, @compat Dict(:offset => offset, :len => len, :header => hdr))
-    #logmsg("sending block read message for offset $offset len $len")
+    @logmsg("sending block read message for offset $offset len $len")
 
     buffer_size_delimited(channel.iob, readblock)
 end
@@ -491,13 +491,13 @@ function send_block_read(reader::HDFSBlockReader)
     isconnected(channel) || connect(channel)
 
     try
-        #logmsg("send block read message")
+        @logmsg("send block read message")
         begin_send(channel)
         buffer_opcode(channel, HDATA_READ_BLOCK)
         buffer_readblock(reader)
         send_buffered(channel, false)
     catch ex
-        #logmsg("exception sending to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception sending to $(channel.host):$(channel.port): $ex")
         disconnect(reader, false)
         rethrow(ex)
     end
@@ -507,11 +507,11 @@ end
 function send_read_status(reader::HDFSBlockReader, status::Int32=Status.SUCCESS)
     channel = reader.channel
     try
-        #logmsg("send read status $status")
+        @logmsg("send read status $status")
         buffer_client_read_status(reader, status)
         send_buffered(channel, false)
     catch ex
-        #logmsg("exception sending to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception sending to $(channel.host):$(channel.port): $ex")
         disconnect(reader, false)
         rethrow(ex)
     end
@@ -526,7 +526,7 @@ function recv_blockop(reader::HDFSBlockReader)
         (checksum_type == ChecksumTypeProto.CHECKSUM_CRC32) || (checksum_type == ChecksumTypeProto.CHECKSUM_CRC32C) || throw(HadoopRpcException("Unknown checksum type $checksum_type"))
         reader.block_op_resp = Nullable(block_resp)
     catch ex
-        #logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
         disconnect(reader, false)
         rethrow(ex)
     end
@@ -536,14 +536,14 @@ end
 function recv_packet_hdr(reader::HDFSBlockReader)
     channel = reader.channel
     try
-        #logmsg("recv block packet message")
+        @logmsg("recv block packet message")
         sock = get(channel.sock)
 
         pkt_len = ntoh(read(sock, UInt32))
         hdr_len = ntoh(read(sock, UInt16))
         hdr_bytes = Array(UInt8, hdr_len)
         read!(sock, hdr_bytes)
-        #logmsg("pkt_hdr <- sock. len $(hdr_len) (pkt_len: $pkt_len)")
+        @logmsg("pkt_hdr <- sock. len $(hdr_len) (pkt_len: $pkt_len)")
 
         pkt_hdr = PacketHeaderProto()
         readproto(IOBuffer(hdr_bytes), pkt_hdr)
@@ -554,11 +554,11 @@ function recv_packet_hdr(reader::HDFSBlockReader)
         reader.chunk = Array(UInt8, reader.chunk_len)
         reader.chunk_count = div(data_len + reader.chunk_len - 1, reader.chunk_len)    # chunk_len-1 to take care of chunks with partial data
         reader.chunks_read = 0
-        #logmsg("received packet with $(reader.chunk_count) chunks of $(reader.chunk_len) bytes each in $data_len bytes of data")
+        @logmsg("received packet with $(reader.chunk_count) chunks of $(reader.chunk_len) bytes each in $data_len bytes of data")
 
         checksums = Array(UInt32, reader.chunk_count)
         read!(sock, checksums)
-        #logmsg("checksums <- sock. len $(sizeof(checksums))")
+        @logmsg("checksums <- sock. len $(sizeof(checksums))")
         for idx in 1:length(checksums)
             checksums[idx] = ntoh(checksums[idx])
         end
@@ -567,10 +567,10 @@ function recv_packet_hdr(reader::HDFSBlockReader)
         reader.packet_read = 4 + sizeof(checksums)
         reader.pkt_hdr = Nullable(pkt_hdr)
         reader.checksums = checksums
-        #logmsg("current read position pkt $(reader.packet_read)/$(reader.packet_len), block $(reader.total_read)/$(reader.len)")
+        @logmsg("current read position pkt $(reader.packet_read)/$(reader.packet_len), block $(reader.total_read)/$(reader.len)")
         nothing
     catch ex
-        #logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
         disconnect(reader, false)
         rethrow(ex)
     end
@@ -581,7 +581,7 @@ eof(reader::HDFSBlockReader) = (reader.total_read >= reader.len)
 
 function verify_pkt_checksums(reader::HDFSBlockReader, buff::Vector{UInt8})
     data_len = length(buff)
-    #logmsg("verifying packet crc data_len: $data_len")
+    @logmsg("verifying packet crc data_len: $data_len")
     (data_len > 0) || return
 
     block_op_resp = get(reader.block_op_resp)
@@ -635,7 +635,7 @@ function read_packet!(reader::HDFSBlockReader, inbuff::Vector{UInt8}, offset::UI
         read!(sock, buff)
         reader.packet_read += packet_remaining
         reader.total_read += packet_remaining
-        #logmsg("recv $(packet_remaining) packet_read $(reader.packet_read), total_read $(reader.total_read)")
+        @logmsg("recv $(packet_remaining) packet_read $(reader.packet_read), total_read $(reader.total_read)")
 
         # verify crc only if required
         reader.chk_crc && verify_pkt_checksums(reader, buff)
@@ -643,7 +643,7 @@ function read_packet!(reader::HDFSBlockReader, inbuff::Vector{UInt8}, offset::UI
         # send the success block read status
         eof(reader) && send_read_status(reader)
     catch ex
-        #logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
         disconnect(reader, false)
         rethrow(ex)
     end
@@ -784,7 +784,7 @@ type HDFSBlockWriter
         port = node.xferPort
 
         channel = _get(_dcpool, host, port)
-        #logmsg("creating block writer for offset $(block.offset) at $host:$port")
+        @logmsg("creating block writer for offset $(block.offset) at $host:$port")
         writer = new(channel, defaults, block, node_info, PipeBuffer(), 0, 0, WriterPipeline())
         writer.pipeline_task = @async process_pipeline(writer)
         writer
@@ -812,11 +812,11 @@ function check_write_buffer(writer::HDFSBlockWriter)
     max_buffer_bytes = defaults.writePacketSize * max_buffer_pkt
     buffered_bytes = nb_available(writer.buffer)
     if ((buffered_bytes >= max_buffer_bytes) || (pending(writer.pkt_pipeline) >= max_buffer_pkt))
-        #logmsg("slow pipeline. pending bytes:$(nb_available(writer.buffer)), packets:$(pending(writer.pkt_pipeline)). waiting...")
+        @logmsg("slow pipeline. pending bytes:$(nb_available(writer.buffer)), packets:$(pending(writer.pkt_pipeline)). waiting...")
         trigger_pkt(writer.pkt_pipeline)
         wait_pkt(writer.pkt_pipeline)
     elseif buffered_bytes >= defaults.writePacketSize
-        #logmsg("triggering pkt_pipeline. buffered:$(nb_available(writer.buffer)), pending packets:$(pending(writer.pkt_pipeline))")
+        @logmsg("triggering pkt_pipeline. buffered:$(nb_available(writer.buffer)), pending packets:$(pending(writer.pkt_pipeline))")
         trigger_pkt(writer.pkt_pipeline)
         yield()
     end
@@ -840,12 +840,12 @@ function write(writer::HDFSBlockWriter, buff::Vector{UInt8})
 end
 
 function flush(writer::HDFSBlockWriter)
-    #logmsg("flush of block writer invoked")
+    @logmsg("flush of block writer invoked")
     flush_and_wait(writer.pkt_pipeline)
 end
 
 function process_pipeline(writer::HDFSBlockWriter)
-    #logmsg("process_pipeline: started")
+    @logmsg("process_pipeline: started")
     pipeline = writer.pkt_pipeline
     defaults = writer.server_defaults
     flushed = false
@@ -870,7 +870,7 @@ function process_pipeline(writer::HDFSBlockWriter)
             sock = get(channel.sock)
             readable_bytes = nb_available(sock)
 
-            #logmsg("processing pipeline. pending $(nb_available(writer.buffer))bytes -> [$(length(pipeline.pkt_prepared)) -> $(length(pipeline.pkt_ackwait)) -> $(length(pipeline.pkt_ackrcvd))]pkts <- $(readable_bytes)bytes flush:$(flushed)")
+            @logmsg("processing pipeline. pending $(nb_available(writer.buffer))bytes -> [$(length(pipeline.pkt_prepared)) -> $(length(pipeline.pkt_ackwait)) -> $(length(pipeline.pkt_ackrcvd))]pkts <- $(readable_bytes)bytes flush:$(flushed)")
             while nb_available(writer.buffer) >= defaults.writePacketSize
                 prepare_packet(writer)
             end
@@ -879,10 +879,10 @@ function process_pipeline(writer::HDFSBlockWriter)
 
             if flushed
                 while nb_available(writer.buffer) > 0
-                    #logmsg("flushing remaining data packet...")
+                    @logmsg("flushing remaining data packet...")
                     prepare_packet(writer)
                 end
-                #logmsg("preparing last empty packet...")
+                @logmsg("preparing last empty packet...")
                 prepare_packet(writer)
             end
 
@@ -896,14 +896,14 @@ function process_pipeline(writer::HDFSBlockWriter)
                 failed = pipeline.failed
                 readable_bytes = nb_available(sock)
             end
-            #logmsg("processed pipeline. pending $(nb_available(writer.buffer))bytes -> [$(length(pipeline.pkt_prepared)) -> $(length(pipeline.pkt_ackwait)) -> $(length(pipeline.pkt_ackrcvd))]pkts <- $(readable_bytes)bytes flush:$(flushed)")
+            @logmsg("processed pipeline. pending $(nb_available(writer.buffer))bytes -> [$(length(pipeline.pkt_prepared)) -> $(length(pipeline.pkt_ackwait)) -> $(length(pipeline.pkt_ackrcvd))]pkts <- $(readable_bytes)bytes flush:$(flushed)")
             trigger_pkt(pipeline)
         end
     catch ex
-        #logmsg("pipeline failed with $ex")
+        @logmsg("pipeline failed with $ex")
         failed = pipeline.failed = true
     end
-    #logmsg("process_pipeline finished. failed: $(failed), flushed: $(flushed)")
+    @logmsg("process_pipeline finished. failed: $(failed), flushed: $(flushed)")
     trigger_pkt(pipeline)
     trigger_flushed(pipeline)
 end
@@ -942,7 +942,7 @@ function buffer_writeblock(writer::HDFSBlockWriter)
                     :maxBytesRcvd => 0,
                     :latestGenerationStamp => exblock.generationStamp,
                     :requestedChecksum => chksum))
-    #logmsg("sending block write message for offset $(block.offset)")
+    @logmsg("sending block write message for offset $(block.offset)")
 
     buffer_size_delimited(channel.iob, writeblock)
 end
@@ -952,13 +952,13 @@ function send_block_write(writer::HDFSBlockWriter)
     channel = writer.channel
 
     try
-        #logmsg("send block write message")
+        @logmsg("send block write message")
         begin_send(channel)
         buffer_opcode(channel, HDATA_WRITE_BLOCK)
         buffer_writeblock(writer)
         send_buffered(channel, false)
     catch ex
-        #logmsg("exception sending to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception sending to $(channel.host):$(channel.port): $ex")
         disconnect(writer, false)
         rethrow(ex)
     end
@@ -970,7 +970,7 @@ function recv_blockop(writer::HDFSBlockWriter)
     try
         recv_blockop(get(channel.sock))
     catch ex
-        #logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception receiving from $(channel.host):$(channel.port): $ex")
         disconnect(writer, false)
         rethrow(ex)
     end
@@ -994,7 +994,7 @@ function populate_checksums(bytes::Vector{UInt8}, chunk_len::UInt32, checksums::
         end
 
         checksums[idx] = hton(calc_chksum)
-        #logmsg("chksum $calc_chksum")
+        @logmsg("chksum $calc_chksum")
         c_offset += c_len
     end
     nothing
@@ -1003,12 +1003,12 @@ end
 function prepare_packet(writer::HDFSBlockWriter)
     defaults = writer.server_defaults
 
-    #logmsg("prepare block packet")
+    @logmsg("prepare block packet")
     bytes_in_packet = min(defaults.writePacketSize, nb_available(writer.buffer))
 
     last_pkt = (bytes_in_packet == 0)
     seq_no = @compat Int64(writer.pkt_seq += 1)
-    #logmsg("packet seqno $seq_no with $(bytes_in_packet)/$(defaults.writePacketSize) bytes is last packet: $last_pkt")
+    @logmsg("packet seqno $seq_no with $(bytes_in_packet)/$(defaults.writePacketSize) bytes is last packet: $last_pkt")
 
     pkt_hdr = protobuild(PacketHeaderProto, @compat Dict(:offsetInBlock => writer.total_written,
                     :seqno => seq_no,
@@ -1034,7 +1034,7 @@ function prepare_packet(writer::HDFSBlockWriter)
 end
 
 function write_packet(writer::HDFSBlockWriter, pkt::PipelinedPacket)
-    #logmsg("write block packet")
+    @logmsg("write block packet")
     channel = writer.channel
 
     try
@@ -1053,24 +1053,24 @@ function write_packet(writer::HDFSBlockWriter, pkt::PipelinedPacket)
         write(sock, pkt.bytes)
 
         ackwait(writer.pkt_pipeline, pkt.seqno)
-        #logmsg("sent packet to $(channel.host):$(channel.port). total_written:$(writer.total_written)")
+        @logmsg("sent packet to $(channel.host):$(channel.port). total_written:$(writer.total_written)")
         nothing
     catch ex
-        #logmsg("exception sending to $(channel.host):$(channel.port): $ex")
+        @logmsg("exception sending to $(channel.host):$(channel.port): $ex")
         disconnect(writer, false)
         rethrow(ex)
     end
 end
 
 function read_packet_ack(writer::HDFSBlockWriter)
-    #logmsg("reading packet ack")
+    @logmsg("reading packet ack")
     channel = writer.channel
 
     try
         sock = get(channel.sock)
-        #logmsg("recv packet ack message")
+        @logmsg("recv packet ack message")
         data_bytes = read_bytes(sock)
-        #logmsg("ack <- sock. len $(length(data_bytes))")
+        @logmsg("ack <- sock. len $(length(data_bytes))")
 
         ack = PipelineAckProto()
         readproto(IOBuffer(data_bytes), ack)
@@ -1081,10 +1081,10 @@ function read_packet_ack(writer::HDFSBlockWriter)
         exblk = writer.block.b
         set_field!(exblk, :numBytes, pipeline.acked_bytes)
 
-        #logmsg("received ack for seqno: $(ack.seqno), status: $(ack.status) bytes acked: $(exblk.numBytes)")
+        @logmsg("received ack for seqno: $(ack.seqno), status: $(ack.status) bytes acked: $(exblk.numBytes)")
         nothing
     catch ex
-        #logmsg("exception reading from $(channel.host):$(channel.port): $ex")
+        @logmsg("exception reading from $(channel.host):$(channel.port): $ex")
         disconnect(writer, false)
         rethrow(ex)
     end

--- a/src/sasl.jl
+++ b/src/sasl.jl
@@ -9,7 +9,7 @@ function digmd5_decode_challenge(challenge::AbstractString)
         end
         comps[n] = v
     end
-    #logmsg("decoded challenge components: $comps")
+    @logmsg("decoded challenge components: $comps")
     comps
 end
 
@@ -73,7 +73,7 @@ end
 buffer_sasl_reqhdr(channel::HadoopRpcChannel) = (channel.sent_call_id = channel.call_id = HRPC_CALL_ID_SASL; buffer_reqhdr(channel, HRPC_CALL_ID_SASL))
 
 function buffer_sasl_message(channel::HadoopRpcChannel, state::Int32, auths::Vector{RpcSaslProto_SaslAuth}=RpcSaslProto_SaslAuth[], token::Vector{UInt8}=UInt8[])
-    #logmsg("buffer SASL message. state:$state, nauths:$(length(auths)), token:$(!isempty(token))")
+    @logmsg("buffer SASL message. state:$state, nauths:$(length(auths)), token:$(!isempty(token))")
     saslmsg = protobuild(RpcSaslProto, @compat Dict(:version => 0, :state => state))
     isempty(auths) || set_field!(saslmsg, :auths, auths)
     isempty(token) || set_field!(saslmsg, :token, token)
@@ -81,10 +81,10 @@ function buffer_sasl_message(channel::HadoopRpcChannel, state::Int32, auths::Vec
 end
 
 function recv_sasl_message(channel::HadoopRpcChannel)
-    #logmsg("recv SASL message")
+    @logmsg("recv SASL message")
     resp = RpcSaslProto()
     recv_rpc_message(channel, resp)
-    #logmsg("received SASL message $resp")
+    @logmsg("received SASL message $resp")
     resp
 end
 
@@ -97,10 +97,10 @@ function conditional_sasl_auth(channel::HadoopRpcChannel)
     tok_alias = token_alias(channel)
     tokens = find_tokens(channel.ugi, alias=tok_alias)
     if isempty(tokens)
-        #logmsg("no token available to authenticate to $tok_alias. skipping")
+        @logmsg("no token available to authenticate to $tok_alias. skipping")
         return false
     end
-    #logmsg("found $(length(tokens)) tokens available to authenticate to $tok_alias. authenticating...")
+    @logmsg("found $(length(tokens)) tokens available to authenticate to $tok_alias. authenticating...")
     token = tokens[1]
     sasl_auth(channel, token)
     true
@@ -121,16 +121,16 @@ function sasl_auth(channel::HadoopRpcChannel, token::TokenProto)
 
     # check if TOKEN/DIGEST-MD5 is one of the supported methods
     nauths = length(resp.auths)
-    #logmsg("server supports $nauths auths")
+    @logmsg("server supports $nauths auths")
     idx_auth = 0
     for idx in 1:length(resp.auths)
         auth = resp.auths[idx]
-        #logmsg("    $idx: $(auth.method)/$(auth.mechanism)")
+        @logmsg("    $idx: $(auth.method)/$(auth.mechanism)")
         ((auth.method == "TOKEN") && (auth.mechanism == "DIGEST-MD5")) || continue
         idx_auth = idx
     end
     if idx_auth == 0
-        #logmsg("no supported auth method found")
+        @logmsg("no supported auth method found")
         throw(HadoopRpcException("no supported authentication method found"))
     end
     auth = resp.auths[idx_auth]
@@ -139,9 +139,9 @@ function sasl_auth(channel::HadoopRpcChannel, token::TokenProto)
     protocol = auth.protocol
     serverId = auth.serverId
     challenge = auth.challenge
-    #logmsg("auth.protocol: $protocol, serverId: $serverId, challenge: $challenge")
+    @logmsg("auth.protocol: $protocol, serverId: $serverId, challenge: $challenge")
     response = digmd5_respond(token, auth.protocol, auth.serverId, auth.challenge)
-    #logmsg("response: $response")
+    @logmsg("response: $response")
 
     # send response as a sasl initiate request
     respauth = protobuild(RpcSaslProto_SaslAuth, @compat Dict(:method => auth.method,
@@ -157,7 +157,7 @@ function sasl_auth(channel::HadoopRpcChannel, token::TokenProto)
 
     # expect a success response
     if resp.state != RpcSaslProto_SaslState.SUCCESS
-        #logmsg("error completing SASL auth. state: $(resp.state). expected state: $(RpcSaslProto_SaslState.SUCCESS)")
+        @logmsg("error completing SASL auth. state: $(resp.state). expected state: $(RpcSaslProto_SaslState.SUCCESS)")
         throw(HadoopRpcException("error completing SASL auth. state: $(resp.state). expected state: $(RpcSaslProto_SaslState.SUCCESS)"))
     end
     nothing


### PR DESCRIPTION
Connections to data nodes are cached. They may get disconnected at the server but remain undetected on the client. Such cases can be safely reconnected and retried.
