### PR TITLE
fix for URIParser changes (schema to scheme)

### DIFF
--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -64,7 +64,7 @@ end
 
 function HDFSFile(uristr::AbstractString)
     uri = URI(uristr)
-    (uri.schema == "hdfs") || throw(HDFSException("Not a HDFS URI: $uristr"))
+    (uri.scheme == "hdfs") || throw(HDFSException("Not a HDFS URI: $uristr"))
     client = HDFSClient(uri.host, uri.port, UserGroupInformation(uri.userinfo))
     HDFSFile(client, uri.path)
 end


### PR DESCRIPTION
Use `URI.scheme` instead of `URI.schema`
