### PR TITLE
use Channel instead of RemoteRef on Julia v0.5

### DIFF
--- a/src/Elly.jl
+++ b/src/Elly.jl
@@ -30,6 +30,14 @@ export YarnAppMaster, register, unregister, kill, can_schedule_mem, can_schedule
 
 export YarnManager, launch, manage
 
+if VERSION < v"0.5.0-"
+typealias Lock RemoteRef
+makelock() = RemoteRef()
+else
+typealias Lock Channel
+makelock() = Channel{Int}(1)
+end
+
 # enable logging only during debugging
 #using Logging
 #const logger = Logging.configure(level=DEBUG)

--- a/src/api_hdfs_io.jl
+++ b/src/api_hdfs_io.jl
@@ -5,7 +5,7 @@
 Default length (bytes) upto which to pre-fetch block metadata.
 (10 blocks of default size)
 """ ->
-const HDFS_READER_WINDOW_LENGTH = @compat UInt64(64*1024*1024*10)
+const HDFS_READER_WINDOW_LENGTH = UInt64(64*1024*1024*10)
 
 @doc doc"""
 # HDFSFileReader
@@ -72,7 +72,7 @@ function seek(reader::HDFSFileReader, n::Integer)
 end
 seekend(reader::HDFSFileReader) = seek(reader, filesize(reader))
 seekstart(reader::HDFSFileReader) = seek(reader, 0)
-skip(reader::HDFSFileReader, n::Integer) = seek(reader, @compat UInt64(n+position(reader)))
+skip(reader::HDFSFileReader, n::Integer) = seek(reader, UInt64(n+position(reader)))
 
 _block_has_offset(block::LocatedBlockProto, offset::UInt64, block_sz::UInt64) = (block.offset <= offset < (block.offset + block_sz))
 

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -133,7 +133,7 @@ function can_schedule(yam::YarnAppMaster, restype::Int32)
 end
 
 function _unregister(yam::YarnAppMaster, finalstatus::Int32, diagnostics::AbstractString)
-    inp = protobuild(FinishApplicationMasterRequestProto, @compat Dict(:final_application_status => finalstatus))
+    inp = protobuild(FinishApplicationMasterRequestProto, Dict(:final_application_status => finalstatus))
     !isempty(yam.tracking_url) && set_field!(inp, :tracking_url, yam.tracking_url)
     !isempty(diagnostics) && set_field!(inp, :diagnostics, diagnostics)
   
@@ -152,8 +152,8 @@ container_release(yam::YarnAppMaster, cids::ContainerIdProto...) = request_relea
 container_start(yam::YarnAppMaster, cid::ContainerIdProto, container_spec::ContainerLaunchContextProto) = container_start(yam, yam.containers.containers[cid], container_spec)
 function container_start(yam::YarnAppMaster, container::ContainerProto, container_spec::ContainerLaunchContextProto)
     @logmsg("starting container $(container)")
-    req = protobuild(StartContainerRequestProto, @compat Dict(:container_launch_context => container_spec, :container_token => container.container_token))
-    inp = protobuild(StartContainersRequestProto, @compat Dict(:start_container_request => [req]))
+    req = protobuild(StartContainerRequestProto, Dict(:container_launch_context => container_spec, :container_token => container.container_token))
+    inp = protobuild(StartContainersRequestProto, Dict(:start_container_request => [req]))
 
     nodeid = container.nodeId
     nm_conn = get_connection(yam.nodes, nodeid)
@@ -177,7 +177,7 @@ container_stop(yam::YarnAppMaster, cid::ContainerIdProto) = container_stop(yam, 
 function container_stop(yam::YarnAppMaster, container::ContainerProto)
     @logmsg("stopping container $container")
 
-    inp = protobuild(StopContainersRequestProto, @compat Dict(:container_id => [container.id]))
+    inp = protobuild(StopContainersRequestProto, Dict(:container_id => [container.id]))
     nodeid = container.nodeId
     nm_conn = get_connection(yam.nodes, nodeid)
     success = false

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -37,12 +37,12 @@ type YarnAppMaster
     response_id::Int32
     
     registration::Nullable{RegisterApplicationMasterResponseProto}
-    lck::RemoteRef
+    lck::Lock
 
     function YarnAppMaster(rmhost::AbstractString, rmport::Integer, ugi::UserGroupInformation,
                 amhost::AbstractString="", amport::Integer=0, amurl::AbstractString="")
         amrm_conn = YarnAMRMProtocol(rmhost, rmport, ugi)
-        lck = RemoteRef()
+        lck = makelock()
         put!(lck, 1)
 
         new(amrm_conn, amhost, amport, amurl, 

--- a/src/api_yarn_base.jl
+++ b/src/api_yarn_base.jl
@@ -301,9 +301,9 @@ end
 function request_alloc(containers::YarnContainers, numcontainers::Int; 
                     mem::Integer=YARN_CONTAINER_MEM_DEFAULT, cpu::Integer=YARN_CONTAINER_CPU_DEFAULT, 
                     loc::AbstractString=YARN_CONTAINER_LOCATION_DEFAULT, priority::Integer=YARN_CONTAINER_PRIORITY_DEFAULT)
-    prio = protobuild(PriorityProto, @compat Dict(:priority => priority))
-    capability = protobuild(ResourceProto, @compat Dict(:memory => mem, :virtual_cores => cpu))
-    req = protobuild(ResourceRequestProto, @compat Dict(:priority => prio,
+    prio = protobuild(PriorityProto, Dict(:priority => priority))
+    capability = protobuild(ResourceProto, Dict(:memory => mem, :virtual_cores => cpu))
+    req = protobuild(ResourceRequestProto, Dict(:priority => prio,
             :resource_name => loc,
             :num_containers => numcontainers,
             :capability => capability))
@@ -351,7 +351,7 @@ function launchcontext(;cmd::AbstractString="", env::Dict=Dict(), service_data::
         envproto = StringStringMapProto[]
         for (n,v) in env
             (isa(n, AbstractString) && isa(v, AbstractString)) || throw(ArgumentError("non string environment variable specified: $(typeof(n)) => $(typeof(v))"))
-            push!(envproto, protobuild(StringStringMapProto, @compat Dict(:key => n, :value => v)))
+            push!(envproto, protobuild(StringStringMapProto, Dict(:key => n, :value => v)))
         end
         set_field!(clc, :environment, envproto)
     end
@@ -359,7 +359,7 @@ function launchcontext(;cmd::AbstractString="", env::Dict=Dict(), service_data::
         svcdataproto = StringBytesMapProto[]
         for (n,v) in service_data
             (isa(n, AbstractString) && isa(v, Vector{UInt8})) || throw(ArgumentError("incompatible service data type specified: $(typeof(n)) => $(typeof(v))"))
-            push!(svcdataproto, protobuild(StringBytesMapProto, @compat Dict(:key => n, :value => v)))
+            push!(svcdataproto, protobuild(StringBytesMapProto, Dict(:key => n, :value => v)))
         end
         set_field!(clc, :service_data, servicedataproto)
     end

--- a/src/api_yarn_client.jl
+++ b/src/api_yarn_client.jl
@@ -164,9 +164,9 @@ function submit(client::YarnClient, container_spec::ContainerLaunchContextProto,
         reuse::Bool=false, unmanaged::Bool=false)
     appid, maxmem, maxcores = _new_app(client)
 
-    prio = protobuild(PriorityProto, @compat Dict(:priority => priority))
-    res = protobuild(ResourceProto, @compat Dict(:memory => mem, :virtual_cores => cores))
-    asc = protobuild(ApplicationSubmissionContextProto, @compat Dict(:application_id => appid,
+    prio = protobuild(PriorityProto, Dict(:priority => priority))
+    res = protobuild(ResourceProto, Dict(:memory => mem, :virtual_cores => cores))
+    asc = protobuild(ApplicationSubmissionContextProto, Dict(:application_id => appid,
                 :application_name => appname,
                 :queue => queue,
                 :priority => prio,
@@ -177,7 +177,7 @@ function submit(client::YarnClient, container_spec::ContainerLaunchContextProto,
                 :applicationType => apptype,
                 :keep_containers_across_application_attempts => reuse))
   
-    inp = protobuild(SubmitApplicationRequestProto, @compat Dict(:application_submission_context => asc))
+    inp = protobuild(SubmitApplicationRequestProto, Dict(:application_submission_context => asc))
 
     submitApplication(client.rm_conn, inp)
     YarnApp(client, appid)
@@ -185,7 +185,7 @@ end
 
 function kill(app::YarnApp)
     client = app.client
-    inp = protobuild(KillApplicationRequestProto, @compat Dict(:application_id => app.appid))
+    inp = protobuild(KillApplicationRequestProto, Dict(:application_id => app.appid))
 
     resp = forceKillApplication(client.rm_conn, inp)
     resp.is_kill_completed
@@ -194,7 +194,7 @@ end
 function status(app::YarnApp, refresh::Bool=true)
     if refresh || isnull(app.status)
         client = app.client
-        inp = protobuild(GetApplicationReportRequestProto, @compat Dict(:application_id => app.appid))
+        inp = protobuild(GetApplicationReportRequestProto, Dict(:application_id => app.appid))
 
         resp = getApplicationReport(client.rm_conn, inp) 
         app.status = isfilled(resp.application_report) ?  Nullable(YarnAppStatus(resp.application_report)) : Nullable{YarnAppStatus}()
@@ -228,7 +228,7 @@ end
 function attempts(app::YarnApp, refresh::Bool=true)
     if refresh || isnull(app.attempts)
         client = app.client
-        inp = protobuild(GetApplicationAttemptsRequestProto, @compat Dict(:application_id => app.appid))
+        inp = protobuild(GetApplicationAttemptsRequestProto, Dict(:application_id => app.appid))
 
         resp = getApplicationAttempts(client.rm_conn, inp)
         atmptlist = app.attempts

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -60,9 +60,9 @@ function _container(cid::AbstractString)
     attempt_id = parse(Int32, parts[4])
     container_id = parse(Int64, parts[5])
 
-    appid_proto = protobuild(ApplicationIdProto, @compat Dict(:id => app_id, :cluster_timestamp => cluster_timestamp))
-    app_attempt_id_proto = protobuild(ApplicationAttemptIdProto, @compat Dict(:application_id => appid_proto, :attemptId => attempt_id))
-    protobuild(ContainerIdProto, @compat Dict(:app_id => appid_proto, :app_attempt_id => app_attempt_id_proto, :id => container_id))
+    appid_proto = protobuild(ApplicationIdProto, Dict(:id => app_id, :cluster_timestamp => cluster_timestamp))
+    app_attempt_id_proto = protobuild(ApplicationAttemptIdProto, Dict(:application_id => appid_proto, :attemptId => attempt_id))
+    protobuild(ContainerIdProto, Dict(:app_id => appid_proto, :app_attempt_id => app_attempt_id_proto, :id => container_id))
 end
 
 _envdict(envdict::Dict) = envdict

--- a/src/sasl.jl
+++ b/src/sasl.jl
@@ -74,7 +74,7 @@ buffer_sasl_reqhdr(channel::HadoopRpcChannel) = (channel.sent_call_id = channel.
 
 function buffer_sasl_message(channel::HadoopRpcChannel, state::Int32, auths::Vector{RpcSaslProto_SaslAuth}=RpcSaslProto_SaslAuth[], token::Vector{UInt8}=UInt8[])
     @logmsg("buffer SASL message. state:$state, nauths:$(length(auths)), token:$(!isempty(token))")
-    saslmsg = protobuild(RpcSaslProto, @compat Dict(:version => 0, :state => state))
+    saslmsg = protobuild(RpcSaslProto, Dict(:version => 0, :state => state))
     isempty(auths) || set_field!(saslmsg, :auths, auths)
     isempty(token) || set_field!(saslmsg, :token, token)
     buffer_size_delimited(channel.iob, saslmsg)
@@ -144,7 +144,7 @@ function sasl_auth(channel::HadoopRpcChannel, token::TokenProto)
     @logmsg("response: $response")
 
     # send response as a sasl initiate request
-    respauth = protobuild(RpcSaslProto_SaslAuth, @compat Dict(:method => auth.method,
+    respauth = protobuild(RpcSaslProto_SaslAuth, Dict(:method => auth.method,
                 :mechanism => auth.mechanism,
                 :protocol => auth.protocol,
                 :serverId => auth.serverId))

--- a/src/ugi.jl
+++ b/src/ugi.jl
@@ -4,7 +4,7 @@ type UserGroupInformation
     tokens::Dict{AbstractString,TokenProto}
     function UserGroupInformation(username::AbstractString="")
         isempty(username) && (username = ENV["USER"])
-        userinfo = protobuild(UserInformationProto, @compat Dict(:realUser => username))
+        userinfo = protobuild(UserInformationProto, Dict(:realUser => username))
         new(userinfo, Dict{AbstractString,TokenProto}())
     end
 end


### PR DESCRIPTION
Julia v0.5 compatibility changes:
- use Channel instead of RemoteRef on Julia v0.5
- remove unnecessary `@compat` use
