### PR TITLE
updates for Julia 0.5 compatibility

### DIFF
--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -393,12 +393,12 @@ function _complete_file(client::HDFSClient, path::AbstractString, last::Nullable
     endresp.result
 end
 
-function _add_block(client::HDFSClient, path::AbstractString, previous::Nullable{LocatedBlockProto}=Nullable{LocatedBlockProto}())
+function _add_block{T<:LocatedBlockProto}(::Type{T}, client::HDFSClient, path::AbstractString, previous::Nullable{T}=Nullable{T}())
     isnull(previous) && (return _add_block(client, path))
     @logmsg("adding next block to $(get(previous).b)")
-    _add_block(client, path, Nullable(get(previous).b))
+    _add_block(ExtendedBlockProto, client, path, Nullable(get(previous).b))
 end
-function _add_block(client::HDFSClient, path::AbstractString, previous::Nullable{ExtendedBlockProto}=Nullable{ExtendedBlockProto}())
+function _add_block{T<:ExtendedBlockProto}(::Type{T}, client::HDFSClient, path::AbstractString, previous::Nullable{T}=Nullable{T}())
     path = abspath(client, path)
 
     inp = protobuild(AddBlockRequestProto, Dict(:src => path,

--- a/src/api_hdfs_io.jl
+++ b/src/api_hdfs_io.jl
@@ -196,8 +196,9 @@ end
 
 #
 # File read
-read!(reader::Elly.HDFSFileReader, a::Array{UInt8, 1}) = _read!(reader, a)
-read!{T}(reader::HDFSFileReader, a::Array{T}) = _read!(reader, a)
+#read!(reader::Elly.HDFSFileReader, a::Array{UInt8}) = _read!(reader, a)
+read!(reader::Elly.HDFSFileReader, a::Array{UInt8,1}) = _read!(reader, a)
+#read!{T}(reader::HDFSFileReader, a::Array{T}) = _read!(reader, a)
 function _read!{T}(reader::HDFSFileReader, a::Array{T})
     remaining::UInt64 = length(a)*sizeof(T)
     offset::UInt64 = 1
@@ -291,7 +292,7 @@ function _write{T<:Union{UInt8,Vector{UInt8}}}(writer::HDFSFileWriter, data::T)
 
     while rem_len > 0
         if isnull(writer.blk_writer)
-            blk = _add_block(writer.client, writer.path, writer.blk)
+            blk = _add_block(LocatedBlockProto, writer.client, writer.path, writer.blk)
             blk_writer = HDFSBlockWriter(blk, _get_server_defaults(writer.client))
             writer.blk_writer = Nullable(blk_writer)
             writer.blk = Nullable(blk)

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -110,7 +110,7 @@ function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Con
     @logmsg("YarnManager launch: initargs: $initargs")
     @logmsg("YarnManager launch: context: $clc")
     on_alloc = (cid) -> container_start(manager.am, cid, clc)
-    callback(manager.am, Nullable(on_alloc), Nullable{Function}())
+    callback(manager.am, Nullable{Function}(on_alloc), Nullable{Function}())
 
     container_allocate(manager.am, convert(Int, np); mem=mem, cpu=cpu, loc=loc, priority=priority)
 


### PR DESCRIPTION
Few changes required to fix compatibility issues with Julia v0.5.
- each function is now a unique type, and a sub type of `Function`
- `_add_block` was ambiguous, but escaped being caught earlier
