### PR TITLE
need to lock node connection

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4.3
 Compat
 ProtoBuf
 URIParser


### PR DESCRIPTION
When Yarn allocates multiple containers on the same node, a single node connection is used to start multiple containers asynchronously. Without any lock, multiple tasks communicating over the same channel mix up data.

Also updated Julia version requirement to v0.4.3.
