### PR TITLE
do not qualify `unsafe_write` with `Base`.

### DIFF
--- a/src/rpc.jl
+++ b/src/rpc.jl
@@ -1102,7 +1102,7 @@ function write_packet(writer::HDFSBlockWriter, pkt::PipelinedPacket)
 
     write(sock, hton(pkt_len))
     write(sock, hton(hdr_len))
-    Base.unsafe_write(sock, pointer(hdr_iob.data), hdr_iob.size)
+    unsafe_write(sock, pointer(hdr_iob.data), hdr_iob.size)
     write(sock, pkt.checksums)
     write(sock, pkt.bytes)
 


### PR DESCRIPTION
`unsafe_write` is not available in `Base` module on Julia v0.4.
It is satisfied by `Compat`.

fixes #21
