### PR TITLE
more HDFS tests, fix `unsafe_wrap` usage on Julia v0.4

### DIFF
--- a/src/api_hdfs_io.jl
+++ b/src/api_hdfs_io.jl
@@ -309,7 +309,7 @@ function _write{T<:Union{UInt8,Vector{UInt8}}}(writer::HDFSFileWriter, data::T)
             flush(blk_writer)
             disconnect(blk_writer, true)
             writer.blk_writer = Nullable{HDFSBlockWriter}()
-            (T <: UInt8) || (rem_data = unsafe_wrap(T, pointer(data, L-rem_len+1), rem_len))
+            (T <: UInt8) || (rem_data = unsafe_wrap(Array, pointer(data, L-rem_len+1), rem_len))
         end
     end
     L


### PR DESCRIPTION
- add more HDFS tests to `hdfstests.jl`
- fix `Compat.unsafe_wrap` usage for Julia v0.4
