### PR TITLE
fix readdir error on folder with many files

### DIFF
--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -148,7 +148,7 @@ function _walkdir(client::HDFSClient, path::AbstractString, process_entry::Funct
                 (cont == false) && break
             end
             if isfilled(dir_list, :remainingEntries) && (dir_list.remainingEntries > 0)
-                start_after = result[end].data
+                start_after = dir_list.partialListing[end].path
             else
                 cont = false
             end

--- a/test/hdfstests.jl
+++ b/test/hdfstests.jl
@@ -91,6 +91,25 @@ function test_hdfs()
 
     println("setting replication factor for $bar_file")
     @test hdfs_set_replication(bar_file, 2)
+
+    cd(hdfsclnt, "/tmp/foo")
+    NFILES = 1000
+    println("create many ($NFILES) files...")
+    for idx in 1:NFILES
+        bar_file = HDFSFile(hdfsclnt, "bar$idx")
+        open(bar_file, "w") do f
+            for idx in 1:nloops
+                write(f, teststr)
+            end
+        end
+    end
+    allfiles = readdir(hdfsclnt, "/tmp/foo")
+    println("delete many ($NFILES) files...")
+    for idx in 1:NFILES
+        bar_file = HDFSFile(hdfsclnt, "bar$idx")
+        rm(bar_file)
+    end
+    @test length(allfiles) >= NFILES
 end
 
 test_hdfs()

--- a/test/hdfstests.jl
+++ b/test/hdfstests.jl
@@ -1,8 +1,8 @@
 using Elly
 using Base.Test
 
-function test_hdfs()
-    hdfsclnt = HDFSClient("localhost", 9000)
+function test_hdfs(host="localhost", port=9000)
+    hdfsclnt = HDFSClient(host, port)
 
     exists(hdfsclnt, "/tmp") || mkdir(hdfsclnt, "/tmp")
 
@@ -111,5 +111,3 @@ function test_hdfs()
     end
     @test length(allfiles) >= NFILES
 end
-
-test_hdfs()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,5 @@
 include("hdfstests.jl")
 include("yarntests.jl")
+
+test_hdfs()
+test_yarn()

--- a/test/yarntests.jl
+++ b/test/yarntests.jl
@@ -1,8 +1,8 @@
 using Elly
 using Base.Test
 
-function test_yarn()
-    yarnclnt = YarnClient("localhost", 8032)
+function test_yarn(host="localhost", port=8032)
+    yarnclnt = YarnClient(host, port)
     nnodes = nodecount(yarnclnt)
     @test nnodes > 0
     println("number of yarn nodes: $nnodes")
@@ -10,6 +10,3 @@ function test_yarn()
     nlist = nodes(yarnclnt)
     show(STDOUT, nlist)
 end
-
-test_yarn()
-


### PR DESCRIPTION
Caused due to an earlier incorrect code refactor, resulting in a leftover undefined variable.

Error log:

```
julia> readdir(hdfsclnt, "/user/hadoop/TrueFX")
ERROR: UndefVarError: result not defined
 in _walkdir(::Elly.HDFSClient, ::String, ::Elly.##8#9{Int64,Array{AbstractString,1}}) at /home/hadoop/.julia/v0.5/Elly/src/api_hdfs_base.jl:151
 in readdir at /home/hadoop/.julia/v0.5/Elly/src/api_hdfs_base.jl:298 [inlined]
 in readdir(::Elly.HDFSClient, ::String) at /home/hadoop/.julia/v0.5/Elly/src/api_hdfs_base.jl:297
```

Also added tests for it.
