### PR TITLE
add compat entries for dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,9 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "1"
+MbedTLS = "0.6.8, 0.7"
+ProtoBuf = "0.7"
+URIParser = "0.4"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
Add compat entries for dependencies.
Also required for tagging package.