### PR TITLE
update to Hadoop v2.10 protocol specs

### DIFF
--- a/genproto.sh
+++ b/genproto.sh
@@ -22,21 +22,23 @@ fi
 
 HADOOP_COMMON_PROTO=${HADOOP_SRC}/hadoop-common-project/hadoop-common/src/main/proto
 HADOOP_HDFS_PROTO=${HADOOP_SRC}/hadoop-hdfs-project/hadoop-hdfs/src/main/proto
+HADOOP_HDFS_CLIENT_PROTO=${HADOOP_SRC}/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto
 HADOOP_MR_PROTO=${HADOOP_SRC}/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/proto
 HADOOP_YARN_PROTO=${HADOOP_SRC}/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto
+HADOOP_YARN_COMMON_PROTO=${HADOOP_SRC}/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto
 
-PROTOC_INCLUDES="-I=${HADOOP_COMMON_PROTO} -I=${HADOOP_HDFS_PROTO} -I=${HADOOP_MR_PROTO} -I=${HADOOP_YARN_PROTO}"
+PROTOC_INCLUDES="-I=${HADOOP_COMMON_PROTO} -I=${HADOOP_HDFS_PROTO} -I=${HADOOP_HDFS_CLIENT_PROTO} -I=${HADOOP_MR_PROTO} -I=${HADOOP_YARN_COMMON_PROTO} -I=${HADOOP_YARN_PROTO}"
 
 PROTO_FILES=
 
-for proto_file in ProtobufRpcEngine RpcHeader Security IpcConnectionContext
+for proto_file in HAServiceProtocol ProtobufRpcEngine RpcHeader Security IpcConnectionContext
 do
     PROTO_FILES="${PROTO_FILES} ${HADOOP_COMMON_PROTO}/${proto_file}.proto"
 done
 
 for proto_file in datatransfer hdfs ClientNamenodeProtocol
 do
-    PROTO_FILES="${PROTO_FILES} ${HADOOP_HDFS_PROTO}/${proto_file}.proto"
+    PROTO_FILES="${PROTO_FILES} ${HADOOP_HDFS_CLIENT_PROTO}/${proto_file}.proto"
 done
 
 for proto_file in yarn_protos yarn_service_protos applicationmaster_protocol applicationclient_protocol containermanagement_protocol application_history_client

--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -391,7 +391,7 @@ function _complete_file(client::HDFSClient, path::AbstractString, last::Union{No
                 :clientName => ELLY_CLIENTNAME))
     if last !== nothing
         setproperty!(endinp, :last, last)
-        @debug("setting last block as $(last)")
+        @debug("setting last block as", last)
     end
 
     endresp = complete(client.nn_conn, endinp)
@@ -400,7 +400,7 @@ end
 
 function _add_block(::Type{T}, client::HDFSClient, path::AbstractString, previous::Union{Nothing,T}=nothing) where T<:LocatedBlockProto
     (previous === nothing) && (return _add_block(ExtendedBlockProto, client, path))
-    @debug("adding next block to $(previous.b)")
+    @debug("adding next block to", previous.b)
     _add_block(ExtendedBlockProto, client, path, previous.b)
 end
 function _add_block(::Type{T}, client::HDFSClient, path::AbstractString, previous::Union{Nothing,T}=nothing) where T<:ExtendedBlockProto

--- a/src/api_hdfs_io.jl
+++ b/src/api_hdfs_io.jl
@@ -173,7 +173,7 @@ function _read_and_buffer(reader::HDFSFileReader, out::Vector{UInt8}, offset::UI
         if reader.blk_reader !== nothing
             blk_reader = reader.blk_reader
             channel = blk_reader.channel
-            @debug("exception receiving from $(channel.host):$(channel.port)", ex=ex)
+            @debug("exception receiving from", host=channel.host, port=channel.port, ex)
         else
             @debug("exception receiving", ex=ex)
         end
@@ -216,7 +216,7 @@ function read!(reader::HDFSFileReader, a::Vector{UInt8})
             end
         else
             nbytes = min(navlb, remaining)
-            @debug("reading $nbytes from buffer", nbytes=nbytes, navlb=navlb, remaining=remaining, offset=offset)
+            @debug("reading from buffer", nbytes=nbytes, navlb=navlb, remaining=remaining, offset=offset)
             Base.read_sub(reader.buffer, a, offset, nbytes)
             reader.fptr += nbytes
         end
@@ -384,7 +384,7 @@ function cp(frompath::Union{HDFSFile,AbstractString}, topath::Union{HDFSFile,Abs
         read!(fromfile, buff)
         write(tofile, buff)
         brem -= bread
-        @debug("remaining $brem/$btot")
+        @debug("progress", remaining=brem, total=btot)
     end
     close(fromfile)
     close(tofile)

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -3,8 +3,10 @@
 # - applicationmaster_protocol.proto
 # - containermanagement_protocol.proto
 
-# In managed mode, the AMRMToken available in file CONTAINER_TOKEN_FILE_ENV_NAME is in Java serialized format (https://apache.googlesource.com/hadoop-common/+/HADOOP-6685/src/java/org/apache/hadoop/security/Credentials.java).
-# Since that is unusable, we are forced to operate only in unmanaged mode, where we get it from the application report.
+# In managed mode, the AMRMToken available in file CONTAINER_TOKEN_FILE_ENV_NAME is in Java serialized format
+#   - Example: https://github.com/apache/hadoop/blob/ab32762f4381449540e1580eeda1cd5198e1e5fa/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java#L348-L351
+#   - Some related debate about this here: https://issues.apache.org/jira/browse/HADOOP-6685
+# Since that is unusable in anything other than Java, we are forced to operate only in unmanaged mode, where we get it from the application report.
 
 const YARN_CONTAINER_MEM_DEFAULT = 128
 const YARN_CONTAINER_CPU_DEFAULT = 1
@@ -66,11 +68,13 @@ end
 
 function show(io::IO, yam::YarnAppMaster)
     show(io, yam.amrm_conn)
-    println(io, "    Memory: available:$(yam.available_mem), max:$(yam.max_mem), can schecule:$(can_schedule_mem(yam))")
-    println(io, "    Cores: available:$(yam.available_cores), max:$(yam.max_cores), can schedule:$(can_schedule_cores(yam))")
-    println(io, "    Queue: $(yam.queue)")
-    show(io, yam.nodes)
-    show(io, yam.containers)
+    if yam.registration !== nothing
+        println(io, "    Memory: available:$(yam.available_mem), max:$(yam.max_mem), can schecule:$(can_schedule_mem(yam))")
+        println(io, "    Cores: available:$(yam.available_cores), max:$(yam.max_cores), can schedule:$(can_schedule_cores(yam))")
+        println(io, "    Queue: $(yam.queue)")
+        show(io, yam.nodes)
+        show(io, yam.containers)
+    end
 end
 
 callback(yam::YarnAppMaster, on_container_alloc::Union{Nothing,Function}, on_container_finish::Union{Nothing,Function}) = 

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -116,7 +116,7 @@ function register(yam::YarnAppMaster)
         yam.max_mem = resp.maximumCapability.memory
         yam.max_cores = resp.maximumCapability.virtual_cores
     end
-    @debug("max capability: mem:$(yam.max_mem), cores:$(yam.max_cores)")
+    @debug("max capability", mem=yam.max_mem, cores=yam.max_cores)
     if isfilled(resp, :queue)
         yam.queue = resp.queue
     end
@@ -155,7 +155,7 @@ container_release(yam::YarnAppMaster, cids::ContainerIdProto...) = request_relea
 
 container_start(yam::YarnAppMaster, cid::ContainerIdProto, container_spec::ContainerLaunchContextProto) = container_start(yam, yam.containers.containers[cid], container_spec)
 function container_start(yam::YarnAppMaster, container::ContainerProto, container_spec::ContainerLaunchContextProto)
-    @debug("starting container $(container)")
+    @debug("starting", container)
     req = protobuild(StartContainerRequestProto, Dict(:container_launch_context => container_spec, :container_token => container.container_token))
     inp = protobuild(StartContainersRequestProto, Dict(:start_container_request => [req]))
 
@@ -181,7 +181,7 @@ end
 
 container_stop(yam::YarnAppMaster, cid::ContainerIdProto) = container_stop(yam, yam.containers.containers[cid])
 function container_stop(yam::YarnAppMaster, container::ContainerProto)
-    @debug("stopping container $container")
+    @debug("stopping", container)
 
     inp = protobuild(StopContainersRequestProto, Dict(:container_id => [container.id]))
     nodeid = container.nodeId
@@ -210,8 +210,7 @@ function _update_rm(yam::YarnAppMaster)
 
     # allocation and release requests
     (alloc_pending,release_pending) = torequest(yam.containers)
-    @debug("alloc pending: $alloc_pending")
-    @debug("release pending: $release_pending")
+    @debug("pending", alloc_pending, release_pending)
     !isempty(alloc_pending) && setproperty!(inp, :ask, alloc_pending)
     !isempty(release_pending) && setproperty!(inp, :release, release_pending)
 

--- a/src/api_yarn_base.jl
+++ b/src/api_yarn_base.jl
@@ -318,9 +318,8 @@ function update(containers::YarnContainers, arp::AllocateResponseProto)
         @debug("have completed containers")
         for contst in arp.completed_container_statuses
             id = contst.container_id
-            @debug("container $id is finished")
             status[id] = contst
-            @debug("id in active: $(id in active)")
+            @debug("container finished", id, active=(id in active))
             (id in active) && pop!(active, id)
             (id in busy) && pop!(busy, id)
             @debug("calling callback for finish")

--- a/src/api_yarn_client.jl
+++ b/src/api_yarn_client.jl
@@ -203,7 +203,7 @@ function status(app::YarnApp, refresh::Bool=true)
 end
 
 function wait_for_state(app::YarnApp, state::Int32, timeout_secs::Int=60)
-    @debug("waiting for application to reach $(APP_STATES[state]) ($state) state")
+    @debug("waiting for application to reach state", statename=APP_STATES[state], state)
     t1 = time() + timeout_secs
     finalstates = (YarnApplicationStateProto.KILLED, YarnApplicationStateProto.FAILED, YarnApplicationStateProto.FINISHED)
     isfinalstate = state in finalstates
@@ -243,7 +243,7 @@ function attempts(app::YarnApp, refresh::Bool=true)
 end
 
 function wait_for_attempt_state(app::YarnApp, attemptid::Int32, state::Int32, timeout_secs::Int=60)
-    @debug("waiting for application attempt $attemptid to reach $(ATTEMPT_STATES[state]) ($state) state")
+    @debug("waiting for application attempt to reach state", attemptid, statename=ATTEMPT_STATES[state], state)
     t1 = time() + timeout_secs
     finalstates = (YarnApplicationAttemptStateProto.APP_ATTEMPT_KILLED, YarnApplicationAttemptStateProto.APP_ATTEMPT_FAILED, YarnApplicationAttemptStateProto.APP_ATTEMPT_FINISHED)
     isfinalstate = state in finalstates
@@ -255,7 +255,7 @@ function wait_for_attempt_state(app::YarnApp, attemptid::Int32, state::Int32, ti
                 atmptstate = report.yarn_application_attempt_state
                 (atmptstate == state) && (return true)
                 isfinalstate || ((atmptstate in finalstates) && (return false))
-                @debug("application attempt $attemptid is in state $(ATTEMPT_STATES[atmptstate]) ($atmptstate) state")
+                @debug("application attempt is in state", attemptid, statename=ATTEMPT_STATES[atmptstate], atmptstate)
                 break
             end
         end

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -13,7 +13,7 @@ struct YarnManager <: ClusterManager
             params[n] = v
         end
         paramkeys = keys(params)
-        @debug("YarnManager constructor: params: $params")
+        @debug("YarnManager constructor", params)
         
         user            = (:user            in paramkeys) ? params[:user]           : ""
         rmport          = (:rmport          in paramkeys) ? params[:rmport]         : 8032
@@ -41,7 +41,7 @@ function show(io::IO, yarncm::YarnManager)
 end
 
 function setup_worker(host, port, cookie)
-    @debug("YarnManager setup_worker: host:$host port:$port cookie:$cookie for container $(ENV[CONTAINER_ID])")
+    @debug("YarnManager setup_worker", host, port, cookie, container=ENV[CONTAINER_ID])
     c = connect(IPv4(host), port)
     if :wait_connected in names(Base; all=true) # < Julia 1.3
         Base.wait_connected(c)
@@ -95,7 +95,7 @@ function _currprocname()
 end
 
 function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Condition)
-    @debug("YarnManager launch: params: $params")
+    @debug("YarnManager launch", params)
 
     paramkeys   = keys(params)
     np          = (:np       in paramkeys)  ? params[:np]               : 1
@@ -120,8 +120,8 @@ function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Con
     initargs = "using Elly; Elly.setup_worker($(ipaddr.host), $(port), $(cookie))"
     clc = launchcontext(cmd="$cmd -e '$initargs'", env=appenv)
 
-    @debug("YarnManager launch: initargs: $initargs")
-    @debug("YarnManager launch: context: $clc")
+    @debug("YarnManager launch", initargs)
+    @debug("YarnManager launch", context=clc)
     on_alloc = (cid) -> container_start(manager.am, cid, clc)
     callback(manager.am, on_alloc, nothing)
 
@@ -160,7 +160,7 @@ end
 function manage(manager::YarnManager, id::Integer, config::WorkerConfig, op::Symbol)
     # This function needs to exist, but so far we don't do anything
     if op == :deregister
-        @debug("YarnManager manage: id:$id, op:$op, nprocs:$(nprocs())")
+        @debug("YarnManager manage", id, op, nprocs=nprocs())
         !manager.keep_connected && (1 == nprocs()) && (@async disconnect(manager))
     end
     nothing

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -120,8 +120,7 @@ function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Con
     initargs = "using Elly; Elly.setup_worker($(ipaddr.host), $(port), $(cookie))"
     clc = launchcontext(cmd="$cmd -e '$initargs'", env=appenv)
 
-    @debug("YarnManager launch", initargs)
-    @debug("YarnManager launch", context=clc)
+    @debug("YarnManager launch", initargs, context=clc)
     on_alloc = (cid) -> container_start(manager.am, cid, clc)
     callback(manager.am, on_alloc, nothing)
 

--- a/src/hadoop/ClientNamenodeProtocol_pb.jl
+++ b/src/hadoop/ClientNamenodeProtocol_pb.jl
@@ -13,12 +13,20 @@ struct __enum_CreateFlagProto <: ProtoEnum
 end #struct __enum_CreateFlagProto
 const CreateFlagProto = __enum_CreateFlagProto()
 
+struct __enum_AddBlockFlagProto <: ProtoEnum
+    NO_LOCAL_WRITE::Int32
+    __enum_AddBlockFlagProto() = new(1)
+end #struct __enum_AddBlockFlagProto
+const AddBlockFlagProto = __enum_AddBlockFlagProto()
+
 struct __enum_DatanodeReportTypeProto <: ProtoEnum
     ALL::Int32
     LIVE::Int32
     DEAD::Int32
     DECOMMISSIONING::Int32
-    __enum_DatanodeReportTypeProto() = new(1,2,3,4)
+    ENTERING_MAINTENANCE::Int32
+    IN_MAINTENANCE::Int32
+    __enum_DatanodeReportTypeProto() = new(1,2,3,4,5,6)
 end #struct __enum_DatanodeReportTypeProto
 const DatanodeReportTypeProto = __enum_DatanodeReportTypeProto()
 
@@ -26,7 +34,8 @@ struct __enum_SafeModeActionProto <: ProtoEnum
     SAFEMODE_LEAVE::Int32
     SAFEMODE_ENTER::Int32
     SAFEMODE_GET::Int32
-    __enum_SafeModeActionProto() = new(1,2,3)
+    SAFEMODE_FORCE_EXIT::Int32
+    __enum_SafeModeActionProto() = new(1,2,3,4)
 end #struct __enum_SafeModeActionProto
 const SafeModeActionProto = __enum_SafeModeActionProto()
 
@@ -130,6 +139,31 @@ mutable struct SetStoragePolicyResponseProto <: ProtoType
     SetStoragePolicyResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct SetStoragePolicyResponseProto
 
+mutable struct UnsetStoragePolicyRequestProto <: ProtoType
+    src::AbstractString
+    UnsetStoragePolicyRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UnsetStoragePolicyRequestProto
+const __req_UnsetStoragePolicyRequestProto = Symbol[:src]
+meta(t::Type{UnsetStoragePolicyRequestProto}) = meta(t, __req_UnsetStoragePolicyRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct UnsetStoragePolicyResponseProto <: ProtoType
+    UnsetStoragePolicyResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UnsetStoragePolicyResponseProto
+
+mutable struct GetStoragePolicyRequestProto <: ProtoType
+    path::AbstractString
+    GetStoragePolicyRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetStoragePolicyRequestProto
+const __req_GetStoragePolicyRequestProto = Symbol[:path]
+meta(t::Type{GetStoragePolicyRequestProto}) = meta(t, __req_GetStoragePolicyRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct GetStoragePolicyResponseProto <: ProtoType
+    storagePolicy::BlockStoragePolicyProto
+    GetStoragePolicyResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetStoragePolicyResponseProto
+const __req_GetStoragePolicyResponseProto = Symbol[:storagePolicy]
+meta(t::Type{GetStoragePolicyResponseProto}) = meta(t, __req_GetStoragePolicyResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct GetStoragePoliciesRequestProto <: ProtoType
     GetStoragePoliciesRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GetStoragePoliciesRequestProto
@@ -186,6 +220,7 @@ mutable struct AddBlockRequestProto <: ProtoType
     excludeNodes::Base.Vector{DatanodeInfoProto}
     fileId::UInt64
     favoredNodes::Base.Vector{AbstractString}
+    flags::Base.Vector{Int32}
     AddBlockRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct AddBlockRequestProto
 const __req_AddBlockRequestProto = Symbol[:src,:clientName]
@@ -295,6 +330,7 @@ mutable struct Rename2RequestProto <: ProtoType
     src::AbstractString
     dst::AbstractString
     overwriteDest::Bool
+    moveToTrash::Bool
     Rename2RequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Rename2RequestProto
 const __req_Rename2RequestProto = Symbol[:src,:dst,:overwriteDest]
@@ -412,6 +448,8 @@ mutable struct GetFsStatsResponseProto <: ProtoType
     corrupt_blocks::UInt64
     missing_blocks::UInt64
     missing_repl_one_blocks::UInt64
+    blocks_in_future::UInt64
+    pending_deletion_blocks::UInt64
     GetFsStatsResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GetFsStatsResponseProto
 const __req_GetFsStatsResponseProto = Symbol[:capacity,:used,:remaining,:under_replicated,:corrupt_blocks,:missing_blocks]
@@ -699,8 +737,11 @@ mutable struct CachePoolInfoProto <: ProtoType
     mode::Int32
     limit::Int64
     maxRelativeExpiry::Int64
+    defaultReplication::UInt32
     CachePoolInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct CachePoolInfoProto
+const __val_CachePoolInfoProto = Dict(:defaultReplication => 1)
+meta(t::Type{CachePoolInfoProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_CachePoolInfoProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct CachePoolStatsProto <: ProtoType
     bytesNeeded::Int64
@@ -794,6 +835,20 @@ mutable struct GetContentSummaryResponseProto <: ProtoType
 end #mutable struct GetContentSummaryResponseProto
 const __req_GetContentSummaryResponseProto = Symbol[:summary]
 meta(t::Type{GetContentSummaryResponseProto}) = meta(t, __req_GetContentSummaryResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct GetQuotaUsageRequestProto <: ProtoType
+    path::AbstractString
+    GetQuotaUsageRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetQuotaUsageRequestProto
+const __req_GetQuotaUsageRequestProto = Symbol[:path]
+meta(t::Type{GetQuotaUsageRequestProto}) = meta(t, __req_GetQuotaUsageRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct GetQuotaUsageResponseProto <: ProtoType
+    usage::QuotaUsageProto
+    GetQuotaUsageResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetQuotaUsageResponseProto
+const __req_GetQuotaUsageResponseProto = Symbol[:usage]
+meta(t::Type{GetQuotaUsageResponseProto}) = meta(t, __req_GetQuotaUsageResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct SetQuotaRequestProto <: ProtoType
     path::AbstractString
@@ -1013,6 +1068,50 @@ end #mutable struct GetEditsFromTxidResponseProto
 const __req_GetEditsFromTxidResponseProto = Symbol[:eventsList]
 meta(t::Type{GetEditsFromTxidResponseProto}) = meta(t, __req_GetEditsFromTxidResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
+mutable struct ListOpenFilesRequestProto <: ProtoType
+    id::Int64
+    ListOpenFilesRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ListOpenFilesRequestProto
+const __req_ListOpenFilesRequestProto = Symbol[:id]
+meta(t::Type{ListOpenFilesRequestProto}) = meta(t, __req_ListOpenFilesRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct OpenFilesBatchResponseProto <: ProtoType
+    id::Int64
+    path::AbstractString
+    clientName::AbstractString
+    clientMachine::AbstractString
+    OpenFilesBatchResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct OpenFilesBatchResponseProto
+const __req_OpenFilesBatchResponseProto = Symbol[:id,:path,:clientName,:clientMachine]
+meta(t::Type{OpenFilesBatchResponseProto}) = meta(t, __req_OpenFilesBatchResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ListOpenFilesResponseProto <: ProtoType
+    entries::Base.Vector{OpenFilesBatchResponseProto}
+    hasMore::Bool
+    ListOpenFilesResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ListOpenFilesResponseProto
+const __req_ListOpenFilesResponseProto = Symbol[:hasMore]
+meta(t::Type{ListOpenFilesResponseProto}) = meta(t, __req_ListOpenFilesResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct MsyncRequestProto <: ProtoType
+    MsyncRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct MsyncRequestProto
+
+mutable struct MsyncResponseProto <: ProtoType
+    MsyncResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct MsyncResponseProto
+
+mutable struct HAServiceStateRequestProto <: ProtoType
+    HAServiceStateRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct HAServiceStateRequestProto
+
+mutable struct HAServiceStateResponseProto <: ProtoType
+    state::Int32
+    HAServiceStateResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct HAServiceStateResponseProto
+const __req_HAServiceStateResponseProto = Symbol[:state]
+meta(t::Type{HAServiceStateResponseProto}) = meta(t, __req_HAServiceStateResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 # service methods for ClientNamenodeProtocol
 const _ClientNamenodeProtocol_methods = MethodDescriptor[
         MethodDescriptor("getBlockLocations", 1, hadoop.hdfs.GetBlockLocationsRequestProto, hadoop.hdfs.GetBlockLocationsResponseProto),
@@ -1021,83 +1120,89 @@ const _ClientNamenodeProtocol_methods = MethodDescriptor[
         MethodDescriptor("append", 4, hadoop.hdfs.AppendRequestProto, hadoop.hdfs.AppendResponseProto),
         MethodDescriptor("setReplication", 5, hadoop.hdfs.SetReplicationRequestProto, hadoop.hdfs.SetReplicationResponseProto),
         MethodDescriptor("setStoragePolicy", 6, hadoop.hdfs.SetStoragePolicyRequestProto, hadoop.hdfs.SetStoragePolicyResponseProto),
-        MethodDescriptor("getStoragePolicies", 7, hadoop.hdfs.GetStoragePoliciesRequestProto, hadoop.hdfs.GetStoragePoliciesResponseProto),
-        MethodDescriptor("setPermission", 8, hadoop.hdfs.SetPermissionRequestProto, hadoop.hdfs.SetPermissionResponseProto),
-        MethodDescriptor("setOwner", 9, hadoop.hdfs.SetOwnerRequestProto, hadoop.hdfs.SetOwnerResponseProto),
-        MethodDescriptor("abandonBlock", 10, hadoop.hdfs.AbandonBlockRequestProto, hadoop.hdfs.AbandonBlockResponseProto),
-        MethodDescriptor("addBlock", 11, hadoop.hdfs.AddBlockRequestProto, hadoop.hdfs.AddBlockResponseProto),
-        MethodDescriptor("getAdditionalDatanode", 12, hadoop.hdfs.GetAdditionalDatanodeRequestProto, hadoop.hdfs.GetAdditionalDatanodeResponseProto),
-        MethodDescriptor("complete", 13, hadoop.hdfs.CompleteRequestProto, hadoop.hdfs.CompleteResponseProto),
-        MethodDescriptor("reportBadBlocks", 14, hadoop.hdfs.ReportBadBlocksRequestProto, hadoop.hdfs.ReportBadBlocksResponseProto),
-        MethodDescriptor("concat", 15, hadoop.hdfs.ConcatRequestProto, hadoop.hdfs.ConcatResponseProto),
-        MethodDescriptor("truncate", 16, hadoop.hdfs.TruncateRequestProto, hadoop.hdfs.TruncateResponseProto),
-        MethodDescriptor("rename", 17, hadoop.hdfs.RenameRequestProto, hadoop.hdfs.RenameResponseProto),
-        MethodDescriptor("rename2", 18, hadoop.hdfs.Rename2RequestProto, hadoop.hdfs.Rename2ResponseProto),
-        MethodDescriptor("delete", 19, hadoop.hdfs.DeleteRequestProto, hadoop.hdfs.DeleteResponseProto),
-        MethodDescriptor("mkdirs", 20, hadoop.hdfs.MkdirsRequestProto, hadoop.hdfs.MkdirsResponseProto),
-        MethodDescriptor("getListing", 21, hadoop.hdfs.GetListingRequestProto, hadoop.hdfs.GetListingResponseProto),
-        MethodDescriptor("renewLease", 22, hadoop.hdfs.RenewLeaseRequestProto, hadoop.hdfs.RenewLeaseResponseProto),
-        MethodDescriptor("recoverLease", 23, hadoop.hdfs.RecoverLeaseRequestProto, hadoop.hdfs.RecoverLeaseResponseProto),
-        MethodDescriptor("getFsStats", 24, hadoop.hdfs.GetFsStatusRequestProto, hadoop.hdfs.GetFsStatsResponseProto),
-        MethodDescriptor("getDatanodeReport", 25, hadoop.hdfs.GetDatanodeReportRequestProto, hadoop.hdfs.GetDatanodeReportResponseProto),
-        MethodDescriptor("getDatanodeStorageReport", 26, hadoop.hdfs.GetDatanodeStorageReportRequestProto, hadoop.hdfs.GetDatanodeStorageReportResponseProto),
-        MethodDescriptor("getPreferredBlockSize", 27, hadoop.hdfs.GetPreferredBlockSizeRequestProto, hadoop.hdfs.GetPreferredBlockSizeResponseProto),
-        MethodDescriptor("setSafeMode", 28, hadoop.hdfs.SetSafeModeRequestProto, hadoop.hdfs.SetSafeModeResponseProto),
-        MethodDescriptor("saveNamespace", 29, hadoop.hdfs.SaveNamespaceRequestProto, hadoop.hdfs.SaveNamespaceResponseProto),
-        MethodDescriptor("rollEdits", 30, hadoop.hdfs.RollEditsRequestProto, hadoop.hdfs.RollEditsResponseProto),
-        MethodDescriptor("restoreFailedStorage", 31, hadoop.hdfs.RestoreFailedStorageRequestProto, hadoop.hdfs.RestoreFailedStorageResponseProto),
-        MethodDescriptor("refreshNodes", 32, hadoop.hdfs.RefreshNodesRequestProto, hadoop.hdfs.RefreshNodesResponseProto),
-        MethodDescriptor("finalizeUpgrade", 33, hadoop.hdfs.FinalizeUpgradeRequestProto, hadoop.hdfs.FinalizeUpgradeResponseProto),
-        MethodDescriptor("rollingUpgrade", 34, hadoop.hdfs.RollingUpgradeRequestProto, hadoop.hdfs.RollingUpgradeResponseProto),
-        MethodDescriptor("listCorruptFileBlocks", 35, hadoop.hdfs.ListCorruptFileBlocksRequestProto, hadoop.hdfs.ListCorruptFileBlocksResponseProto),
-        MethodDescriptor("metaSave", 36, hadoop.hdfs.MetaSaveRequestProto, hadoop.hdfs.MetaSaveResponseProto),
-        MethodDescriptor("getFileInfo", 37, hadoop.hdfs.GetFileInfoRequestProto, hadoop.hdfs.GetFileInfoResponseProto),
-        MethodDescriptor("addCacheDirective", 38, hadoop.hdfs.AddCacheDirectiveRequestProto, hadoop.hdfs.AddCacheDirectiveResponseProto),
-        MethodDescriptor("modifyCacheDirective", 39, hadoop.hdfs.ModifyCacheDirectiveRequestProto, hadoop.hdfs.ModifyCacheDirectiveResponseProto),
-        MethodDescriptor("removeCacheDirective", 40, hadoop.hdfs.RemoveCacheDirectiveRequestProto, hadoop.hdfs.RemoveCacheDirectiveResponseProto),
-        MethodDescriptor("listCacheDirectives", 41, hadoop.hdfs.ListCacheDirectivesRequestProto, hadoop.hdfs.ListCacheDirectivesResponseProto),
-        MethodDescriptor("addCachePool", 42, hadoop.hdfs.AddCachePoolRequestProto, hadoop.hdfs.AddCachePoolResponseProto),
-        MethodDescriptor("modifyCachePool", 43, hadoop.hdfs.ModifyCachePoolRequestProto, hadoop.hdfs.ModifyCachePoolResponseProto),
-        MethodDescriptor("removeCachePool", 44, hadoop.hdfs.RemoveCachePoolRequestProto, hadoop.hdfs.RemoveCachePoolResponseProto),
-        MethodDescriptor("listCachePools", 45, hadoop.hdfs.ListCachePoolsRequestProto, hadoop.hdfs.ListCachePoolsResponseProto),
-        MethodDescriptor("getFileLinkInfo", 46, hadoop.hdfs.GetFileLinkInfoRequestProto, hadoop.hdfs.GetFileLinkInfoResponseProto),
-        MethodDescriptor("getContentSummary", 47, hadoop.hdfs.GetContentSummaryRequestProto, hadoop.hdfs.GetContentSummaryResponseProto),
-        MethodDescriptor("setQuota", 48, hadoop.hdfs.SetQuotaRequestProto, hadoop.hdfs.SetQuotaResponseProto),
-        MethodDescriptor("fsync", 49, hadoop.hdfs.FsyncRequestProto, hadoop.hdfs.FsyncResponseProto),
-        MethodDescriptor("setTimes", 50, hadoop.hdfs.SetTimesRequestProto, hadoop.hdfs.SetTimesResponseProto),
-        MethodDescriptor("createSymlink", 51, hadoop.hdfs.CreateSymlinkRequestProto, hadoop.hdfs.CreateSymlinkResponseProto),
-        MethodDescriptor("getLinkTarget", 52, hadoop.hdfs.GetLinkTargetRequestProto, hadoop.hdfs.GetLinkTargetResponseProto),
-        MethodDescriptor("updateBlockForPipeline", 53, hadoop.hdfs.UpdateBlockForPipelineRequestProto, hadoop.hdfs.UpdateBlockForPipelineResponseProto),
-        MethodDescriptor("updatePipeline", 54, hadoop.hdfs.UpdatePipelineRequestProto, hadoop.hdfs.UpdatePipelineResponseProto),
-        MethodDescriptor("getDelegationToken", 55, hadoop.common.GetDelegationTokenRequestProto, hadoop.common.GetDelegationTokenResponseProto),
-        MethodDescriptor("renewDelegationToken", 56, hadoop.common.RenewDelegationTokenRequestProto, hadoop.common.RenewDelegationTokenResponseProto),
-        MethodDescriptor("cancelDelegationToken", 57, hadoop.common.CancelDelegationTokenRequestProto, hadoop.common.CancelDelegationTokenResponseProto),
-        MethodDescriptor("setBalancerBandwidth", 58, hadoop.hdfs.SetBalancerBandwidthRequestProto, hadoop.hdfs.SetBalancerBandwidthResponseProto),
-        MethodDescriptor("getDataEncryptionKey", 59, hadoop.hdfs.GetDataEncryptionKeyRequestProto, hadoop.hdfs.GetDataEncryptionKeyResponseProto),
-        MethodDescriptor("createSnapshot", 60, hadoop.hdfs.CreateSnapshotRequestProto, hadoop.hdfs.CreateSnapshotResponseProto),
-        MethodDescriptor("renameSnapshot", 61, hadoop.hdfs.RenameSnapshotRequestProto, hadoop.hdfs.RenameSnapshotResponseProto),
-        MethodDescriptor("allowSnapshot", 62, hadoop.hdfs.AllowSnapshotRequestProto, hadoop.hdfs.AllowSnapshotResponseProto),
-        MethodDescriptor("disallowSnapshot", 63, hadoop.hdfs.DisallowSnapshotRequestProto, hadoop.hdfs.DisallowSnapshotResponseProto),
-        MethodDescriptor("getSnapshottableDirListing", 64, hadoop.hdfs.GetSnapshottableDirListingRequestProto, hadoop.hdfs.GetSnapshottableDirListingResponseProto),
-        MethodDescriptor("deleteSnapshot", 65, hadoop.hdfs.DeleteSnapshotRequestProto, hadoop.hdfs.DeleteSnapshotResponseProto),
-        MethodDescriptor("getSnapshotDiffReport", 66, hadoop.hdfs.GetSnapshotDiffReportRequestProto, hadoop.hdfs.GetSnapshotDiffReportResponseProto),
-        MethodDescriptor("isFileClosed", 67, hadoop.hdfs.IsFileClosedRequestProto, hadoop.hdfs.IsFileClosedResponseProto),
-        MethodDescriptor("modifyAclEntries", 68, hadoop.hdfs.ModifyAclEntriesRequestProto, hadoop.hdfs.ModifyAclEntriesResponseProto),
-        MethodDescriptor("removeAclEntries", 69, hadoop.hdfs.RemoveAclEntriesRequestProto, hadoop.hdfs.RemoveAclEntriesResponseProto),
-        MethodDescriptor("removeDefaultAcl", 70, hadoop.hdfs.RemoveDefaultAclRequestProto, hadoop.hdfs.RemoveDefaultAclResponseProto),
-        MethodDescriptor("removeAcl", 71, hadoop.hdfs.RemoveAclRequestProto, hadoop.hdfs.RemoveAclResponseProto),
-        MethodDescriptor("setAcl", 72, hadoop.hdfs.SetAclRequestProto, hadoop.hdfs.SetAclResponseProto),
-        MethodDescriptor("getAclStatus", 73, hadoop.hdfs.GetAclStatusRequestProto, hadoop.hdfs.GetAclStatusResponseProto),
-        MethodDescriptor("setXAttr", 74, hadoop.hdfs.SetXAttrRequestProto, hadoop.hdfs.SetXAttrResponseProto),
-        MethodDescriptor("getXAttrs", 75, hadoop.hdfs.GetXAttrsRequestProto, hadoop.hdfs.GetXAttrsResponseProto),
-        MethodDescriptor("listXAttrs", 76, hadoop.hdfs.ListXAttrsRequestProto, hadoop.hdfs.ListXAttrsResponseProto),
-        MethodDescriptor("removeXAttr", 77, hadoop.hdfs.RemoveXAttrRequestProto, hadoop.hdfs.RemoveXAttrResponseProto),
-        MethodDescriptor("checkAccess", 78, hadoop.hdfs.CheckAccessRequestProto, hadoop.hdfs.CheckAccessResponseProto),
-        MethodDescriptor("createEncryptionZone", 79, hadoop.hdfs.CreateEncryptionZoneRequestProto, hadoop.hdfs.CreateEncryptionZoneResponseProto),
-        MethodDescriptor("listEncryptionZones", 80, hadoop.hdfs.ListEncryptionZonesRequestProto, hadoop.hdfs.ListEncryptionZonesResponseProto),
-        MethodDescriptor("getEZForPath", 81, hadoop.hdfs.GetEZForPathRequestProto, hadoop.hdfs.GetEZForPathResponseProto),
-        MethodDescriptor("getCurrentEditLogTxid", 82, hadoop.hdfs.GetCurrentEditLogTxidRequestProto, hadoop.hdfs.GetCurrentEditLogTxidResponseProto),
-        MethodDescriptor("getEditsFromTxid", 83, hadoop.hdfs.GetEditsFromTxidRequestProto, hadoop.hdfs.GetEditsFromTxidResponseProto)
+        MethodDescriptor("unsetStoragePolicy", 7, hadoop.hdfs.UnsetStoragePolicyRequestProto, hadoop.hdfs.UnsetStoragePolicyResponseProto),
+        MethodDescriptor("getStoragePolicy", 8, hadoop.hdfs.GetStoragePolicyRequestProto, hadoop.hdfs.GetStoragePolicyResponseProto),
+        MethodDescriptor("getStoragePolicies", 9, hadoop.hdfs.GetStoragePoliciesRequestProto, hadoop.hdfs.GetStoragePoliciesResponseProto),
+        MethodDescriptor("setPermission", 10, hadoop.hdfs.SetPermissionRequestProto, hadoop.hdfs.SetPermissionResponseProto),
+        MethodDescriptor("setOwner", 11, hadoop.hdfs.SetOwnerRequestProto, hadoop.hdfs.SetOwnerResponseProto),
+        MethodDescriptor("abandonBlock", 12, hadoop.hdfs.AbandonBlockRequestProto, hadoop.hdfs.AbandonBlockResponseProto),
+        MethodDescriptor("addBlock", 13, hadoop.hdfs.AddBlockRequestProto, hadoop.hdfs.AddBlockResponseProto),
+        MethodDescriptor("getAdditionalDatanode", 14, hadoop.hdfs.GetAdditionalDatanodeRequestProto, hadoop.hdfs.GetAdditionalDatanodeResponseProto),
+        MethodDescriptor("complete", 15, hadoop.hdfs.CompleteRequestProto, hadoop.hdfs.CompleteResponseProto),
+        MethodDescriptor("reportBadBlocks", 16, hadoop.hdfs.ReportBadBlocksRequestProto, hadoop.hdfs.ReportBadBlocksResponseProto),
+        MethodDescriptor("concat", 17, hadoop.hdfs.ConcatRequestProto, hadoop.hdfs.ConcatResponseProto),
+        MethodDescriptor("truncate", 18, hadoop.hdfs.TruncateRequestProto, hadoop.hdfs.TruncateResponseProto),
+        MethodDescriptor("rename", 19, hadoop.hdfs.RenameRequestProto, hadoop.hdfs.RenameResponseProto),
+        MethodDescriptor("rename2", 20, hadoop.hdfs.Rename2RequestProto, hadoop.hdfs.Rename2ResponseProto),
+        MethodDescriptor("delete", 21, hadoop.hdfs.DeleteRequestProto, hadoop.hdfs.DeleteResponseProto),
+        MethodDescriptor("mkdirs", 22, hadoop.hdfs.MkdirsRequestProto, hadoop.hdfs.MkdirsResponseProto),
+        MethodDescriptor("getListing", 23, hadoop.hdfs.GetListingRequestProto, hadoop.hdfs.GetListingResponseProto),
+        MethodDescriptor("renewLease", 24, hadoop.hdfs.RenewLeaseRequestProto, hadoop.hdfs.RenewLeaseResponseProto),
+        MethodDescriptor("recoverLease", 25, hadoop.hdfs.RecoverLeaseRequestProto, hadoop.hdfs.RecoverLeaseResponseProto),
+        MethodDescriptor("getFsStats", 26, hadoop.hdfs.GetFsStatusRequestProto, hadoop.hdfs.GetFsStatsResponseProto),
+        MethodDescriptor("getDatanodeReport", 27, hadoop.hdfs.GetDatanodeReportRequestProto, hadoop.hdfs.GetDatanodeReportResponseProto),
+        MethodDescriptor("getDatanodeStorageReport", 28, hadoop.hdfs.GetDatanodeStorageReportRequestProto, hadoop.hdfs.GetDatanodeStorageReportResponseProto),
+        MethodDescriptor("getPreferredBlockSize", 29, hadoop.hdfs.GetPreferredBlockSizeRequestProto, hadoop.hdfs.GetPreferredBlockSizeResponseProto),
+        MethodDescriptor("setSafeMode", 30, hadoop.hdfs.SetSafeModeRequestProto, hadoop.hdfs.SetSafeModeResponseProto),
+        MethodDescriptor("saveNamespace", 31, hadoop.hdfs.SaveNamespaceRequestProto, hadoop.hdfs.SaveNamespaceResponseProto),
+        MethodDescriptor("rollEdits", 32, hadoop.hdfs.RollEditsRequestProto, hadoop.hdfs.RollEditsResponseProto),
+        MethodDescriptor("restoreFailedStorage", 33, hadoop.hdfs.RestoreFailedStorageRequestProto, hadoop.hdfs.RestoreFailedStorageResponseProto),
+        MethodDescriptor("refreshNodes", 34, hadoop.hdfs.RefreshNodesRequestProto, hadoop.hdfs.RefreshNodesResponseProto),
+        MethodDescriptor("finalizeUpgrade", 35, hadoop.hdfs.FinalizeUpgradeRequestProto, hadoop.hdfs.FinalizeUpgradeResponseProto),
+        MethodDescriptor("rollingUpgrade", 36, hadoop.hdfs.RollingUpgradeRequestProto, hadoop.hdfs.RollingUpgradeResponseProto),
+        MethodDescriptor("listCorruptFileBlocks", 37, hadoop.hdfs.ListCorruptFileBlocksRequestProto, hadoop.hdfs.ListCorruptFileBlocksResponseProto),
+        MethodDescriptor("metaSave", 38, hadoop.hdfs.MetaSaveRequestProto, hadoop.hdfs.MetaSaveResponseProto),
+        MethodDescriptor("getFileInfo", 39, hadoop.hdfs.GetFileInfoRequestProto, hadoop.hdfs.GetFileInfoResponseProto),
+        MethodDescriptor("addCacheDirective", 40, hadoop.hdfs.AddCacheDirectiveRequestProto, hadoop.hdfs.AddCacheDirectiveResponseProto),
+        MethodDescriptor("modifyCacheDirective", 41, hadoop.hdfs.ModifyCacheDirectiveRequestProto, hadoop.hdfs.ModifyCacheDirectiveResponseProto),
+        MethodDescriptor("removeCacheDirective", 42, hadoop.hdfs.RemoveCacheDirectiveRequestProto, hadoop.hdfs.RemoveCacheDirectiveResponseProto),
+        MethodDescriptor("listCacheDirectives", 43, hadoop.hdfs.ListCacheDirectivesRequestProto, hadoop.hdfs.ListCacheDirectivesResponseProto),
+        MethodDescriptor("addCachePool", 44, hadoop.hdfs.AddCachePoolRequestProto, hadoop.hdfs.AddCachePoolResponseProto),
+        MethodDescriptor("modifyCachePool", 45, hadoop.hdfs.ModifyCachePoolRequestProto, hadoop.hdfs.ModifyCachePoolResponseProto),
+        MethodDescriptor("removeCachePool", 46, hadoop.hdfs.RemoveCachePoolRequestProto, hadoop.hdfs.RemoveCachePoolResponseProto),
+        MethodDescriptor("listCachePools", 47, hadoop.hdfs.ListCachePoolsRequestProto, hadoop.hdfs.ListCachePoolsResponseProto),
+        MethodDescriptor("getFileLinkInfo", 48, hadoop.hdfs.GetFileLinkInfoRequestProto, hadoop.hdfs.GetFileLinkInfoResponseProto),
+        MethodDescriptor("getContentSummary", 49, hadoop.hdfs.GetContentSummaryRequestProto, hadoop.hdfs.GetContentSummaryResponseProto),
+        MethodDescriptor("setQuota", 50, hadoop.hdfs.SetQuotaRequestProto, hadoop.hdfs.SetQuotaResponseProto),
+        MethodDescriptor("fsync", 51, hadoop.hdfs.FsyncRequestProto, hadoop.hdfs.FsyncResponseProto),
+        MethodDescriptor("setTimes", 52, hadoop.hdfs.SetTimesRequestProto, hadoop.hdfs.SetTimesResponseProto),
+        MethodDescriptor("createSymlink", 53, hadoop.hdfs.CreateSymlinkRequestProto, hadoop.hdfs.CreateSymlinkResponseProto),
+        MethodDescriptor("getLinkTarget", 54, hadoop.hdfs.GetLinkTargetRequestProto, hadoop.hdfs.GetLinkTargetResponseProto),
+        MethodDescriptor("updateBlockForPipeline", 55, hadoop.hdfs.UpdateBlockForPipelineRequestProto, hadoop.hdfs.UpdateBlockForPipelineResponseProto),
+        MethodDescriptor("updatePipeline", 56, hadoop.hdfs.UpdatePipelineRequestProto, hadoop.hdfs.UpdatePipelineResponseProto),
+        MethodDescriptor("getDelegationToken", 57, hadoop.common.GetDelegationTokenRequestProto, hadoop.common.GetDelegationTokenResponseProto),
+        MethodDescriptor("renewDelegationToken", 58, hadoop.common.RenewDelegationTokenRequestProto, hadoop.common.RenewDelegationTokenResponseProto),
+        MethodDescriptor("cancelDelegationToken", 59, hadoop.common.CancelDelegationTokenRequestProto, hadoop.common.CancelDelegationTokenResponseProto),
+        MethodDescriptor("setBalancerBandwidth", 60, hadoop.hdfs.SetBalancerBandwidthRequestProto, hadoop.hdfs.SetBalancerBandwidthResponseProto),
+        MethodDescriptor("getDataEncryptionKey", 61, hadoop.hdfs.GetDataEncryptionKeyRequestProto, hadoop.hdfs.GetDataEncryptionKeyResponseProto),
+        MethodDescriptor("createSnapshot", 62, hadoop.hdfs.CreateSnapshotRequestProto, hadoop.hdfs.CreateSnapshotResponseProto),
+        MethodDescriptor("renameSnapshot", 63, hadoop.hdfs.RenameSnapshotRequestProto, hadoop.hdfs.RenameSnapshotResponseProto),
+        MethodDescriptor("allowSnapshot", 64, hadoop.hdfs.AllowSnapshotRequestProto, hadoop.hdfs.AllowSnapshotResponseProto),
+        MethodDescriptor("disallowSnapshot", 65, hadoop.hdfs.DisallowSnapshotRequestProto, hadoop.hdfs.DisallowSnapshotResponseProto),
+        MethodDescriptor("getSnapshottableDirListing", 66, hadoop.hdfs.GetSnapshottableDirListingRequestProto, hadoop.hdfs.GetSnapshottableDirListingResponseProto),
+        MethodDescriptor("deleteSnapshot", 67, hadoop.hdfs.DeleteSnapshotRequestProto, hadoop.hdfs.DeleteSnapshotResponseProto),
+        MethodDescriptor("getSnapshotDiffReport", 68, hadoop.hdfs.GetSnapshotDiffReportRequestProto, hadoop.hdfs.GetSnapshotDiffReportResponseProto),
+        MethodDescriptor("isFileClosed", 69, hadoop.hdfs.IsFileClosedRequestProto, hadoop.hdfs.IsFileClosedResponseProto),
+        MethodDescriptor("modifyAclEntries", 70, hadoop.hdfs.ModifyAclEntriesRequestProto, hadoop.hdfs.ModifyAclEntriesResponseProto),
+        MethodDescriptor("removeAclEntries", 71, hadoop.hdfs.RemoveAclEntriesRequestProto, hadoop.hdfs.RemoveAclEntriesResponseProto),
+        MethodDescriptor("removeDefaultAcl", 72, hadoop.hdfs.RemoveDefaultAclRequestProto, hadoop.hdfs.RemoveDefaultAclResponseProto),
+        MethodDescriptor("removeAcl", 73, hadoop.hdfs.RemoveAclRequestProto, hadoop.hdfs.RemoveAclResponseProto),
+        MethodDescriptor("setAcl", 74, hadoop.hdfs.SetAclRequestProto, hadoop.hdfs.SetAclResponseProto),
+        MethodDescriptor("getAclStatus", 75, hadoop.hdfs.GetAclStatusRequestProto, hadoop.hdfs.GetAclStatusResponseProto),
+        MethodDescriptor("setXAttr", 76, hadoop.hdfs.SetXAttrRequestProto, hadoop.hdfs.SetXAttrResponseProto),
+        MethodDescriptor("getXAttrs", 77, hadoop.hdfs.GetXAttrsRequestProto, hadoop.hdfs.GetXAttrsResponseProto),
+        MethodDescriptor("listXAttrs", 78, hadoop.hdfs.ListXAttrsRequestProto, hadoop.hdfs.ListXAttrsResponseProto),
+        MethodDescriptor("removeXAttr", 79, hadoop.hdfs.RemoveXAttrRequestProto, hadoop.hdfs.RemoveXAttrResponseProto),
+        MethodDescriptor("checkAccess", 80, hadoop.hdfs.CheckAccessRequestProto, hadoop.hdfs.CheckAccessResponseProto),
+        MethodDescriptor("createEncryptionZone", 81, hadoop.hdfs.CreateEncryptionZoneRequestProto, hadoop.hdfs.CreateEncryptionZoneResponseProto),
+        MethodDescriptor("listEncryptionZones", 82, hadoop.hdfs.ListEncryptionZonesRequestProto, hadoop.hdfs.ListEncryptionZonesResponseProto),
+        MethodDescriptor("getEZForPath", 83, hadoop.hdfs.GetEZForPathRequestProto, hadoop.hdfs.GetEZForPathResponseProto),
+        MethodDescriptor("getCurrentEditLogTxid", 84, hadoop.hdfs.GetCurrentEditLogTxidRequestProto, hadoop.hdfs.GetCurrentEditLogTxidResponseProto),
+        MethodDescriptor("getEditsFromTxid", 85, hadoop.hdfs.GetEditsFromTxidRequestProto, hadoop.hdfs.GetEditsFromTxidResponseProto),
+        MethodDescriptor("getQuotaUsage", 86, hadoop.hdfs.GetQuotaUsageRequestProto, hadoop.hdfs.GetQuotaUsageResponseProto),
+        MethodDescriptor("listOpenFiles", 87, hadoop.hdfs.ListOpenFilesRequestProto, hadoop.hdfs.ListOpenFilesResponseProto),
+        MethodDescriptor("msync", 88, hadoop.hdfs.MsyncRequestProto, hadoop.hdfs.MsyncResponseProto),
+        MethodDescriptor("getHAServiceState", 89, hadoop.hdfs.HAServiceStateRequestProto, hadoop.hdfs.HAServiceStateResponseProto)
     ] # const _ClientNamenodeProtocol_methods
 const _ClientNamenodeProtocol_desc = ServiceDescriptor("hadoop.hdfs.ClientNamenodeProtocol", 1, _ClientNamenodeProtocol_methods)
 
@@ -1131,235 +1236,253 @@ setReplication(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcCon
 setStoragePolicy(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetStoragePolicyRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[6], controller, inp, done)
 setStoragePolicy(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetStoragePolicyRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[6], controller, inp)
 
-getStoragePolicies(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePoliciesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[7], controller, inp, done)
-getStoragePolicies(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePoliciesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[7], controller, inp)
+unsetStoragePolicy(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.UnsetStoragePolicyRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[7], controller, inp, done)
+unsetStoragePolicy(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.UnsetStoragePolicyRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[7], controller, inp)
 
-setPermission(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetPermissionRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[8], controller, inp, done)
-setPermission(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetPermissionRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[8], controller, inp)
+getStoragePolicy(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePolicyRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[8], controller, inp, done)
+getStoragePolicy(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePolicyRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[8], controller, inp)
 
-setOwner(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetOwnerRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[9], controller, inp, done)
-setOwner(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetOwnerRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[9], controller, inp)
+getStoragePolicies(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePoliciesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[9], controller, inp, done)
+getStoragePolicies(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetStoragePoliciesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[9], controller, inp)
 
-abandonBlock(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AbandonBlockRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[10], controller, inp, done)
-abandonBlock(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AbandonBlockRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[10], controller, inp)
+setPermission(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetPermissionRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[10], controller, inp, done)
+setPermission(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetPermissionRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[10], controller, inp)
 
-addBlock(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddBlockRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[11], controller, inp, done)
-addBlock(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddBlockRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[11], controller, inp)
+setOwner(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetOwnerRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[11], controller, inp, done)
+setOwner(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetOwnerRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[11], controller, inp)
 
-getAdditionalDatanode(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAdditionalDatanodeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[12], controller, inp, done)
-getAdditionalDatanode(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAdditionalDatanodeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[12], controller, inp)
+abandonBlock(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AbandonBlockRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[12], controller, inp, done)
+abandonBlock(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AbandonBlockRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[12], controller, inp)
 
-complete(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CompleteRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[13], controller, inp, done)
-complete(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CompleteRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[13], controller, inp)
+addBlock(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddBlockRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[13], controller, inp, done)
+addBlock(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddBlockRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[13], controller, inp)
 
-reportBadBlocks(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ReportBadBlocksRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[14], controller, inp, done)
-reportBadBlocks(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ReportBadBlocksRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[14], controller, inp)
+getAdditionalDatanode(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAdditionalDatanodeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[14], controller, inp, done)
+getAdditionalDatanode(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAdditionalDatanodeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[14], controller, inp)
 
-concat(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ConcatRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[15], controller, inp, done)
-concat(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ConcatRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[15], controller, inp)
+complete(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CompleteRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[15], controller, inp, done)
+complete(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CompleteRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[15], controller, inp)
 
-truncate(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.TruncateRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[16], controller, inp, done)
-truncate(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.TruncateRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[16], controller, inp)
+reportBadBlocks(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ReportBadBlocksRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[16], controller, inp, done)
+reportBadBlocks(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ReportBadBlocksRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[16], controller, inp)
 
-rename(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[17], controller, inp, done)
-rename(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[17], controller, inp)
+concat(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ConcatRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[17], controller, inp, done)
+concat(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ConcatRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[17], controller, inp)
 
-rename2(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.Rename2RequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[18], controller, inp, done)
-rename2(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.Rename2RequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[18], controller, inp)
+truncate(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.TruncateRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[18], controller, inp, done)
+truncate(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.TruncateRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[18], controller, inp)
 
-delete(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[19], controller, inp, done)
-delete(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[19], controller, inp)
+rename(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[19], controller, inp, done)
+rename(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[19], controller, inp)
 
-mkdirs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.MkdirsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[20], controller, inp, done)
-mkdirs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.MkdirsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[20], controller, inp)
+rename2(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.Rename2RequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[20], controller, inp, done)
+rename2(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.Rename2RequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[20], controller, inp)
 
-getListing(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetListingRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[21], controller, inp, done)
-getListing(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetListingRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[21], controller, inp)
+delete(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[21], controller, inp, done)
+delete(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[21], controller, inp)
 
-renewLease(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenewLeaseRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[22], controller, inp, done)
-renewLease(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenewLeaseRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[22], controller, inp)
+mkdirs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.MkdirsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[22], controller, inp, done)
+mkdirs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.MkdirsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[22], controller, inp)
 
-recoverLease(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RecoverLeaseRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[23], controller, inp, done)
-recoverLease(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RecoverLeaseRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[23], controller, inp)
+getListing(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetListingRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[23], controller, inp, done)
+getListing(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetListingRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[23], controller, inp)
 
-getFsStats(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFsStatusRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[24], controller, inp, done)
-getFsStats(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFsStatusRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[24], controller, inp)
+renewLease(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenewLeaseRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[24], controller, inp, done)
+renewLease(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenewLeaseRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[24], controller, inp)
 
-getDatanodeReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[25], controller, inp, done)
-getDatanodeReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[25], controller, inp)
+recoverLease(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RecoverLeaseRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[25], controller, inp, done)
+recoverLease(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RecoverLeaseRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[25], controller, inp)
 
-getDatanodeStorageReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeStorageReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[26], controller, inp, done)
-getDatanodeStorageReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeStorageReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[26], controller, inp)
+getFsStats(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFsStatusRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[26], controller, inp, done)
+getFsStats(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFsStatusRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[26], controller, inp)
 
-getPreferredBlockSize(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetPreferredBlockSizeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[27], controller, inp, done)
-getPreferredBlockSize(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetPreferredBlockSizeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[27], controller, inp)
+getDatanodeReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[27], controller, inp, done)
+getDatanodeReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[27], controller, inp)
 
-setSafeMode(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetSafeModeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[28], controller, inp, done)
-setSafeMode(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetSafeModeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[28], controller, inp)
+getDatanodeStorageReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeStorageReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[28], controller, inp, done)
+getDatanodeStorageReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDatanodeStorageReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[28], controller, inp)
 
-saveNamespace(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SaveNamespaceRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[29], controller, inp, done)
-saveNamespace(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SaveNamespaceRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[29], controller, inp)
+getPreferredBlockSize(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetPreferredBlockSizeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[29], controller, inp, done)
+getPreferredBlockSize(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetPreferredBlockSizeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[29], controller, inp)
 
-rollEdits(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollEditsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[30], controller, inp, done)
-rollEdits(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollEditsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[30], controller, inp)
+setSafeMode(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetSafeModeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[30], controller, inp, done)
+setSafeMode(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetSafeModeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[30], controller, inp)
 
-restoreFailedStorage(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RestoreFailedStorageRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[31], controller, inp, done)
-restoreFailedStorage(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RestoreFailedStorageRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[31], controller, inp)
+saveNamespace(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SaveNamespaceRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[31], controller, inp, done)
+saveNamespace(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SaveNamespaceRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[31], controller, inp)
 
-refreshNodes(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RefreshNodesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[32], controller, inp, done)
-refreshNodes(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RefreshNodesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[32], controller, inp)
+rollEdits(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollEditsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[32], controller, inp, done)
+rollEdits(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollEditsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[32], controller, inp)
 
-finalizeUpgrade(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.FinalizeUpgradeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[33], controller, inp, done)
-finalizeUpgrade(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.FinalizeUpgradeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[33], controller, inp)
+restoreFailedStorage(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RestoreFailedStorageRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[33], controller, inp, done)
+restoreFailedStorage(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RestoreFailedStorageRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[33], controller, inp)
 
-rollingUpgrade(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollingUpgradeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[34], controller, inp, done)
-rollingUpgrade(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollingUpgradeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[34], controller, inp)
+refreshNodes(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RefreshNodesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[34], controller, inp, done)
+refreshNodes(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RefreshNodesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[34], controller, inp)
 
-listCorruptFileBlocks(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCorruptFileBlocksRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[35], controller, inp, done)
-listCorruptFileBlocks(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCorruptFileBlocksRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[35], controller, inp)
+finalizeUpgrade(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.FinalizeUpgradeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[35], controller, inp, done)
+finalizeUpgrade(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.FinalizeUpgradeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[35], controller, inp)
 
-metaSave(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.MetaSaveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[36], controller, inp, done)
-metaSave(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.MetaSaveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[36], controller, inp)
+rollingUpgrade(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollingUpgradeRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[36], controller, inp, done)
+rollingUpgrade(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RollingUpgradeRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[36], controller, inp)
 
-getFileInfo(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileInfoRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[37], controller, inp, done)
-getFileInfo(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileInfoRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[37], controller, inp)
+listCorruptFileBlocks(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCorruptFileBlocksRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[37], controller, inp, done)
+listCorruptFileBlocks(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCorruptFileBlocksRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[37], controller, inp)
 
-addCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[38], controller, inp, done)
-addCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[38], controller, inp)
+metaSave(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.MetaSaveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[38], controller, inp, done)
+metaSave(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.MetaSaveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[38], controller, inp)
 
-modifyCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[39], controller, inp, done)
-modifyCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[39], controller, inp)
+getFileInfo(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileInfoRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[39], controller, inp, done)
+getFileInfo(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileInfoRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[39], controller, inp)
 
-removeCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[40], controller, inp, done)
-removeCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[40], controller, inp)
+addCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[40], controller, inp, done)
+addCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[40], controller, inp)
 
-listCacheDirectives(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCacheDirectivesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[41], controller, inp, done)
-listCacheDirectives(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCacheDirectivesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[41], controller, inp)
+modifyCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[41], controller, inp, done)
+modifyCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[41], controller, inp)
 
-addCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[42], controller, inp, done)
-addCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[42], controller, inp)
+removeCacheDirective(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCacheDirectiveRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[42], controller, inp, done)
+removeCacheDirective(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCacheDirectiveRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[42], controller, inp)
 
-modifyCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[43], controller, inp, done)
-modifyCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[43], controller, inp)
+listCacheDirectives(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCacheDirectivesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[43], controller, inp, done)
+listCacheDirectives(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCacheDirectivesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[43], controller, inp)
 
-removeCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[44], controller, inp, done)
-removeCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[44], controller, inp)
+addCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[44], controller, inp, done)
+addCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AddCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[44], controller, inp)
 
-listCachePools(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCachePoolsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[45], controller, inp, done)
-listCachePools(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCachePoolsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[45], controller, inp)
+modifyCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[45], controller, inp, done)
+modifyCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[45], controller, inp)
 
-getFileLinkInfo(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileLinkInfoRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[46], controller, inp, done)
-getFileLinkInfo(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileLinkInfoRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[46], controller, inp)
+removeCachePool(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCachePoolRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[46], controller, inp, done)
+removeCachePool(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveCachePoolRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[46], controller, inp)
 
-getContentSummary(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetContentSummaryRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[47], controller, inp, done)
-getContentSummary(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetContentSummaryRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[47], controller, inp)
+listCachePools(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCachePoolsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[47], controller, inp, done)
+listCachePools(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListCachePoolsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[47], controller, inp)
 
-setQuota(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetQuotaRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[48], controller, inp, done)
-setQuota(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetQuotaRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[48], controller, inp)
+getFileLinkInfo(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileLinkInfoRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[48], controller, inp, done)
+getFileLinkInfo(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetFileLinkInfoRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[48], controller, inp)
 
-fsync(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.FsyncRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[49], controller, inp, done)
-fsync(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.FsyncRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[49], controller, inp)
+getContentSummary(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetContentSummaryRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[49], controller, inp, done)
+getContentSummary(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetContentSummaryRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[49], controller, inp)
 
-setTimes(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetTimesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[50], controller, inp, done)
-setTimes(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetTimesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[50], controller, inp)
+setQuota(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetQuotaRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[50], controller, inp, done)
+setQuota(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetQuotaRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[50], controller, inp)
 
-createSymlink(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSymlinkRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[51], controller, inp, done)
-createSymlink(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSymlinkRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[51], controller, inp)
+fsync(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.FsyncRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[51], controller, inp, done)
+fsync(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.FsyncRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[51], controller, inp)
 
-getLinkTarget(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetLinkTargetRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[52], controller, inp, done)
-getLinkTarget(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetLinkTargetRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[52], controller, inp)
+setTimes(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetTimesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[52], controller, inp, done)
+setTimes(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetTimesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[52], controller, inp)
 
-updateBlockForPipeline(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdateBlockForPipelineRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[53], controller, inp, done)
-updateBlockForPipeline(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdateBlockForPipelineRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[53], controller, inp)
+createSymlink(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSymlinkRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[53], controller, inp, done)
+createSymlink(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSymlinkRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[53], controller, inp)
 
-updatePipeline(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdatePipelineRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[54], controller, inp, done)
-updatePipeline(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdatePipelineRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[54], controller, inp)
+getLinkTarget(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetLinkTargetRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[54], controller, inp, done)
+getLinkTarget(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetLinkTargetRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[54], controller, inp)
 
-getDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[55], controller, inp, done)
-getDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[55], controller, inp)
+updateBlockForPipeline(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdateBlockForPipelineRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[55], controller, inp, done)
+updateBlockForPipeline(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdateBlockForPipelineRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[55], controller, inp)
 
-renewDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[56], controller, inp, done)
-renewDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[56], controller, inp)
+updatePipeline(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdatePipelineRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[56], controller, inp, done)
+updatePipeline(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.UpdatePipelineRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[56], controller, inp)
 
-cancelDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[57], controller, inp, done)
-cancelDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[57], controller, inp)
+getDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[57], controller, inp, done)
+getDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[57], controller, inp)
 
-setBalancerBandwidth(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetBalancerBandwidthRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[58], controller, inp, done)
-setBalancerBandwidth(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetBalancerBandwidthRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[58], controller, inp)
+renewDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[58], controller, inp, done)
+renewDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[58], controller, inp)
 
-getDataEncryptionKey(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDataEncryptionKeyRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[59], controller, inp, done)
-getDataEncryptionKey(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDataEncryptionKeyRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[59], controller, inp)
+cancelDelegationToken(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[59], controller, inp, done)
+cancelDelegationToken(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[59], controller, inp)
 
-createSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[60], controller, inp, done)
-createSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[60], controller, inp)
+setBalancerBandwidth(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetBalancerBandwidthRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[60], controller, inp, done)
+setBalancerBandwidth(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetBalancerBandwidthRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[60], controller, inp)
 
-renameSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[61], controller, inp, done)
-renameSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[61], controller, inp)
+getDataEncryptionKey(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDataEncryptionKeyRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[61], controller, inp, done)
+getDataEncryptionKey(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetDataEncryptionKeyRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[61], controller, inp)
 
-allowSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AllowSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[62], controller, inp, done)
-allowSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AllowSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[62], controller, inp)
+createSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[62], controller, inp, done)
+createSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[62], controller, inp)
 
-disallowSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DisallowSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[63], controller, inp, done)
-disallowSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DisallowSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[63], controller, inp)
+renameSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[63], controller, inp, done)
+renameSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RenameSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[63], controller, inp)
 
-getSnapshottableDirListing(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshottableDirListingRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[64], controller, inp, done)
-getSnapshottableDirListing(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshottableDirListingRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[64], controller, inp)
+allowSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.AllowSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[64], controller, inp, done)
+allowSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.AllowSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[64], controller, inp)
 
-deleteSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[65], controller, inp, done)
-deleteSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[65], controller, inp)
+disallowSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DisallowSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[65], controller, inp, done)
+disallowSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DisallowSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[65], controller, inp)
 
-getSnapshotDiffReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshotDiffReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[66], controller, inp, done)
-getSnapshotDiffReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshotDiffReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[66], controller, inp)
+getSnapshottableDirListing(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshottableDirListingRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[66], controller, inp, done)
+getSnapshottableDirListing(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshottableDirListingRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[66], controller, inp)
 
-isFileClosed(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.IsFileClosedRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[67], controller, inp, done)
-isFileClosed(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.IsFileClosedRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[67], controller, inp)
+deleteSnapshot(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteSnapshotRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[67], controller, inp, done)
+deleteSnapshot(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.DeleteSnapshotRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[67], controller, inp)
 
-modifyAclEntries(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyAclEntriesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[68], controller, inp, done)
-modifyAclEntries(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyAclEntriesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[68], controller, inp)
+getSnapshotDiffReport(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshotDiffReportRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[68], controller, inp, done)
+getSnapshotDiffReport(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetSnapshotDiffReportRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[68], controller, inp)
 
-removeAclEntries(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclEntriesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[69], controller, inp, done)
-removeAclEntries(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclEntriesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[69], controller, inp)
+isFileClosed(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.IsFileClosedRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[69], controller, inp, done)
+isFileClosed(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.IsFileClosedRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[69], controller, inp)
 
-removeDefaultAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveDefaultAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[70], controller, inp, done)
-removeDefaultAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveDefaultAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[70], controller, inp)
+modifyAclEntries(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyAclEntriesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[70], controller, inp, done)
+modifyAclEntries(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ModifyAclEntriesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[70], controller, inp)
 
-removeAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[71], controller, inp, done)
-removeAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[71], controller, inp)
+removeAclEntries(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclEntriesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[71], controller, inp, done)
+removeAclEntries(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclEntriesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[71], controller, inp)
 
-setAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[72], controller, inp, done)
-setAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[72], controller, inp)
+removeDefaultAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveDefaultAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[72], controller, inp, done)
+removeDefaultAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveDefaultAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[72], controller, inp)
 
-getAclStatus(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAclStatusRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[73], controller, inp, done)
-getAclStatus(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAclStatusRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[73], controller, inp)
+removeAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[73], controller, inp, done)
+removeAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[73], controller, inp)
 
-setXAttr(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetXAttrRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[74], controller, inp, done)
-setXAttr(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetXAttrRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[74], controller, inp)
+setAcl(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetAclRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[74], controller, inp, done)
+setAcl(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetAclRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[74], controller, inp)
 
-getXAttrs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetXAttrsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[75], controller, inp, done)
-getXAttrs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetXAttrsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[75], controller, inp)
+getAclStatus(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAclStatusRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[75], controller, inp, done)
+getAclStatus(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetAclStatusRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[75], controller, inp)
 
-listXAttrs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListXAttrsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[76], controller, inp, done)
-listXAttrs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListXAttrsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[76], controller, inp)
+setXAttr(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetXAttrRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[76], controller, inp, done)
+setXAttr(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.SetXAttrRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[76], controller, inp)
 
-removeXAttr(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveXAttrRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[77], controller, inp, done)
-removeXAttr(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveXAttrRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[77], controller, inp)
+getXAttrs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetXAttrsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[77], controller, inp, done)
+getXAttrs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetXAttrsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[77], controller, inp)
 
-checkAccess(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CheckAccessRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[78], controller, inp, done)
-checkAccess(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CheckAccessRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[78], controller, inp)
+listXAttrs(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListXAttrsRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[78], controller, inp, done)
+listXAttrs(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListXAttrsRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[78], controller, inp)
 
-createEncryptionZone(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateEncryptionZoneRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[79], controller, inp, done)
-createEncryptionZone(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateEncryptionZoneRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[79], controller, inp)
+removeXAttr(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveXAttrRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[79], controller, inp, done)
+removeXAttr(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.RemoveXAttrRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[79], controller, inp)
 
-listEncryptionZones(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListEncryptionZonesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[80], controller, inp, done)
-listEncryptionZones(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListEncryptionZonesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[80], controller, inp)
+checkAccess(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CheckAccessRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[80], controller, inp, done)
+checkAccess(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CheckAccessRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[80], controller, inp)
 
-getEZForPath(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEZForPathRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[81], controller, inp, done)
-getEZForPath(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEZForPathRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[81], controller, inp)
+createEncryptionZone(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateEncryptionZoneRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[81], controller, inp, done)
+createEncryptionZone(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.CreateEncryptionZoneRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[81], controller, inp)
 
-getCurrentEditLogTxid(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetCurrentEditLogTxidRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[82], controller, inp, done)
-getCurrentEditLogTxid(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetCurrentEditLogTxidRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[82], controller, inp)
+listEncryptionZones(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListEncryptionZonesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[82], controller, inp, done)
+listEncryptionZones(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListEncryptionZonesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[82], controller, inp)
 
-getEditsFromTxid(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEditsFromTxidRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[83], controller, inp, done)
-getEditsFromTxid(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEditsFromTxidRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[83], controller, inp)
+getEZForPath(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEZForPathRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[83], controller, inp, done)
+getEZForPath(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEZForPathRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[83], controller, inp)
 
-export CreateFlagProto, DatanodeReportTypeProto, SafeModeActionProto, RollingUpgradeActionProto, CacheFlagProto, GetBlockLocationsRequestProto, GetBlockLocationsResponseProto, GetServerDefaultsRequestProto, GetServerDefaultsResponseProto, CreateRequestProto, CreateResponseProto, AppendRequestProto, AppendResponseProto, SetReplicationRequestProto, SetReplicationResponseProto, SetStoragePolicyRequestProto, SetStoragePolicyResponseProto, GetStoragePoliciesRequestProto, GetStoragePoliciesResponseProto, SetPermissionRequestProto, SetPermissionResponseProto, SetOwnerRequestProto, SetOwnerResponseProto, AbandonBlockRequestProto, AbandonBlockResponseProto, AddBlockRequestProto, AddBlockResponseProto, GetAdditionalDatanodeRequestProto, GetAdditionalDatanodeResponseProto, CompleteRequestProto, CompleteResponseProto, ReportBadBlocksRequestProto, ReportBadBlocksResponseProto, ConcatRequestProto, ConcatResponseProto, TruncateRequestProto, TruncateResponseProto, RenameRequestProto, RenameResponseProto, Rename2RequestProto, Rename2ResponseProto, DeleteRequestProto, DeleteResponseProto, MkdirsRequestProto, MkdirsResponseProto, GetListingRequestProto, GetListingResponseProto, GetSnapshottableDirListingRequestProto, GetSnapshottableDirListingResponseProto, GetSnapshotDiffReportRequestProto, GetSnapshotDiffReportResponseProto, RenewLeaseRequestProto, RenewLeaseResponseProto, RecoverLeaseRequestProto, RecoverLeaseResponseProto, GetFsStatusRequestProto, GetFsStatsResponseProto, GetDatanodeReportRequestProto, GetDatanodeReportResponseProto, GetDatanodeStorageReportRequestProto, DatanodeStorageReportProto, GetDatanodeStorageReportResponseProto, GetPreferredBlockSizeRequestProto, GetPreferredBlockSizeResponseProto, SetSafeModeRequestProto, SetSafeModeResponseProto, SaveNamespaceRequestProto, SaveNamespaceResponseProto, RollEditsRequestProto, RollEditsResponseProto, RestoreFailedStorageRequestProto, RestoreFailedStorageResponseProto, RefreshNodesRequestProto, RefreshNodesResponseProto, FinalizeUpgradeRequestProto, FinalizeUpgradeResponseProto, RollingUpgradeRequestProto, RollingUpgradeInfoProto, RollingUpgradeResponseProto, ListCorruptFileBlocksRequestProto, ListCorruptFileBlocksResponseProto, MetaSaveRequestProto, MetaSaveResponseProto, GetFileInfoRequestProto, GetFileInfoResponseProto, IsFileClosedRequestProto, IsFileClosedResponseProto, CacheDirectiveInfoProto, CacheDirectiveInfoExpirationProto, CacheDirectiveStatsProto, AddCacheDirectiveRequestProto, AddCacheDirectiveResponseProto, ModifyCacheDirectiveRequestProto, ModifyCacheDirectiveResponseProto, RemoveCacheDirectiveRequestProto, RemoveCacheDirectiveResponseProto, ListCacheDirectivesRequestProto, CacheDirectiveEntryProto, ListCacheDirectivesResponseProto, CachePoolInfoProto, CachePoolStatsProto, AddCachePoolRequestProto, AddCachePoolResponseProto, ModifyCachePoolRequestProto, ModifyCachePoolResponseProto, RemoveCachePoolRequestProto, RemoveCachePoolResponseProto, ListCachePoolsRequestProto, ListCachePoolsResponseProto, CachePoolEntryProto, GetFileLinkInfoRequestProto, GetFileLinkInfoResponseProto, GetContentSummaryRequestProto, GetContentSummaryResponseProto, SetQuotaRequestProto, SetQuotaResponseProto, FsyncRequestProto, FsyncResponseProto, SetTimesRequestProto, SetTimesResponseProto, CreateSymlinkRequestProto, CreateSymlinkResponseProto, GetLinkTargetRequestProto, GetLinkTargetResponseProto, UpdateBlockForPipelineRequestProto, UpdateBlockForPipelineResponseProto, UpdatePipelineRequestProto, UpdatePipelineResponseProto, SetBalancerBandwidthRequestProto, SetBalancerBandwidthResponseProto, GetDataEncryptionKeyRequestProto, GetDataEncryptionKeyResponseProto, CreateSnapshotRequestProto, CreateSnapshotResponseProto, RenameSnapshotRequestProto, RenameSnapshotResponseProto, AllowSnapshotRequestProto, AllowSnapshotResponseProto, DisallowSnapshotRequestProto, DisallowSnapshotResponseProto, DeleteSnapshotRequestProto, DeleteSnapshotResponseProto, CheckAccessRequestProto, CheckAccessResponseProto, GetCurrentEditLogTxidRequestProto, GetCurrentEditLogTxidResponseProto, GetEditsFromTxidRequestProto, GetEditsFromTxidResponseProto, ClientNamenodeProtocol, ClientNamenodeProtocolStub, ClientNamenodeProtocolBlockingStub, getBlockLocations, getServerDefaults, create, append, setReplication, setStoragePolicy, getStoragePolicies, setPermission, setOwner, abandonBlock, addBlock, getAdditionalDatanode, complete, reportBadBlocks, concat, truncate, rename, rename2, delete, mkdirs, getListing, renewLease, recoverLease, getFsStats, getDatanodeReport, getDatanodeStorageReport, getPreferredBlockSize, setSafeMode, saveNamespace, rollEdits, restoreFailedStorage, refreshNodes, finalizeUpgrade, rollingUpgrade, listCorruptFileBlocks, metaSave, getFileInfo, addCacheDirective, modifyCacheDirective, removeCacheDirective, listCacheDirectives, addCachePool, modifyCachePool, removeCachePool, listCachePools, getFileLinkInfo, getContentSummary, setQuota, fsync, setTimes, createSymlink, getLinkTarget, updateBlockForPipeline, updatePipeline, getDelegationToken, renewDelegationToken, cancelDelegationToken, setBalancerBandwidth, getDataEncryptionKey, createSnapshot, renameSnapshot, allowSnapshot, disallowSnapshot, getSnapshottableDirListing, deleteSnapshot, getSnapshotDiffReport, isFileClosed, modifyAclEntries, removeAclEntries, removeDefaultAcl, removeAcl, setAcl, getAclStatus, setXAttr, getXAttrs, listXAttrs, removeXAttr, checkAccess, createEncryptionZone, listEncryptionZones, getEZForPath, getCurrentEditLogTxid, getEditsFromTxid
+getCurrentEditLogTxid(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetCurrentEditLogTxidRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[84], controller, inp, done)
+getCurrentEditLogTxid(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetCurrentEditLogTxidRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[84], controller, inp)
+
+getEditsFromTxid(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEditsFromTxidRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[85], controller, inp, done)
+getEditsFromTxid(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetEditsFromTxidRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[85], controller, inp)
+
+getQuotaUsage(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetQuotaUsageRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[86], controller, inp, done)
+getQuotaUsage(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.GetQuotaUsageRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[86], controller, inp)
+
+listOpenFiles(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListOpenFilesRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[87], controller, inp, done)
+listOpenFiles(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.ListOpenFilesRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[87], controller, inp)
+
+msync(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.MsyncRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[88], controller, inp, done)
+msync(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.MsyncRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[88], controller, inp)
+
+getHAServiceState(stub::ClientNamenodeProtocolStub, controller::ProtoRpcController, inp::hadoop.hdfs.HAServiceStateRequestProto, done::Function) = call_method(stub.impl, _ClientNamenodeProtocol_methods[89], controller, inp, done)
+getHAServiceState(stub::ClientNamenodeProtocolBlockingStub, controller::ProtoRpcController, inp::hadoop.hdfs.HAServiceStateRequestProto) = call_method(stub.impl, _ClientNamenodeProtocol_methods[89], controller, inp)
+
+export CreateFlagProto, AddBlockFlagProto, DatanodeReportTypeProto, SafeModeActionProto, RollingUpgradeActionProto, CacheFlagProto, GetBlockLocationsRequestProto, GetBlockLocationsResponseProto, GetServerDefaultsRequestProto, GetServerDefaultsResponseProto, CreateRequestProto, CreateResponseProto, AppendRequestProto, AppendResponseProto, SetReplicationRequestProto, SetReplicationResponseProto, SetStoragePolicyRequestProto, SetStoragePolicyResponseProto, UnsetStoragePolicyRequestProto, UnsetStoragePolicyResponseProto, GetStoragePolicyRequestProto, GetStoragePolicyResponseProto, GetStoragePoliciesRequestProto, GetStoragePoliciesResponseProto, SetPermissionRequestProto, SetPermissionResponseProto, SetOwnerRequestProto, SetOwnerResponseProto, AbandonBlockRequestProto, AbandonBlockResponseProto, AddBlockRequestProto, AddBlockResponseProto, GetAdditionalDatanodeRequestProto, GetAdditionalDatanodeResponseProto, CompleteRequestProto, CompleteResponseProto, ReportBadBlocksRequestProto, ReportBadBlocksResponseProto, ConcatRequestProto, ConcatResponseProto, TruncateRequestProto, TruncateResponseProto, RenameRequestProto, RenameResponseProto, Rename2RequestProto, Rename2ResponseProto, DeleteRequestProto, DeleteResponseProto, MkdirsRequestProto, MkdirsResponseProto, GetListingRequestProto, GetListingResponseProto, GetSnapshottableDirListingRequestProto, GetSnapshottableDirListingResponseProto, GetSnapshotDiffReportRequestProto, GetSnapshotDiffReportResponseProto, RenewLeaseRequestProto, RenewLeaseResponseProto, RecoverLeaseRequestProto, RecoverLeaseResponseProto, GetFsStatusRequestProto, GetFsStatsResponseProto, GetDatanodeReportRequestProto, GetDatanodeReportResponseProto, GetDatanodeStorageReportRequestProto, DatanodeStorageReportProto, GetDatanodeStorageReportResponseProto, GetPreferredBlockSizeRequestProto, GetPreferredBlockSizeResponseProto, SetSafeModeRequestProto, SetSafeModeResponseProto, SaveNamespaceRequestProto, SaveNamespaceResponseProto, RollEditsRequestProto, RollEditsResponseProto, RestoreFailedStorageRequestProto, RestoreFailedStorageResponseProto, RefreshNodesRequestProto, RefreshNodesResponseProto, FinalizeUpgradeRequestProto, FinalizeUpgradeResponseProto, RollingUpgradeRequestProto, RollingUpgradeInfoProto, RollingUpgradeResponseProto, ListCorruptFileBlocksRequestProto, ListCorruptFileBlocksResponseProto, MetaSaveRequestProto, MetaSaveResponseProto, GetFileInfoRequestProto, GetFileInfoResponseProto, IsFileClosedRequestProto, IsFileClosedResponseProto, CacheDirectiveInfoProto, CacheDirectiveInfoExpirationProto, CacheDirectiveStatsProto, AddCacheDirectiveRequestProto, AddCacheDirectiveResponseProto, ModifyCacheDirectiveRequestProto, ModifyCacheDirectiveResponseProto, RemoveCacheDirectiveRequestProto, RemoveCacheDirectiveResponseProto, ListCacheDirectivesRequestProto, CacheDirectiveEntryProto, ListCacheDirectivesResponseProto, CachePoolInfoProto, CachePoolStatsProto, AddCachePoolRequestProto, AddCachePoolResponseProto, ModifyCachePoolRequestProto, ModifyCachePoolResponseProto, RemoveCachePoolRequestProto, RemoveCachePoolResponseProto, ListCachePoolsRequestProto, ListCachePoolsResponseProto, CachePoolEntryProto, GetFileLinkInfoRequestProto, GetFileLinkInfoResponseProto, GetContentSummaryRequestProto, GetContentSummaryResponseProto, GetQuotaUsageRequestProto, GetQuotaUsageResponseProto, SetQuotaRequestProto, SetQuotaResponseProto, FsyncRequestProto, FsyncResponseProto, SetTimesRequestProto, SetTimesResponseProto, CreateSymlinkRequestProto, CreateSymlinkResponseProto, GetLinkTargetRequestProto, GetLinkTargetResponseProto, UpdateBlockForPipelineRequestProto, UpdateBlockForPipelineResponseProto, UpdatePipelineRequestProto, UpdatePipelineResponseProto, SetBalancerBandwidthRequestProto, SetBalancerBandwidthResponseProto, GetDataEncryptionKeyRequestProto, GetDataEncryptionKeyResponseProto, CreateSnapshotRequestProto, CreateSnapshotResponseProto, RenameSnapshotRequestProto, RenameSnapshotResponseProto, AllowSnapshotRequestProto, AllowSnapshotResponseProto, DisallowSnapshotRequestProto, DisallowSnapshotResponseProto, DeleteSnapshotRequestProto, DeleteSnapshotResponseProto, CheckAccessRequestProto, CheckAccessResponseProto, GetCurrentEditLogTxidRequestProto, GetCurrentEditLogTxidResponseProto, GetEditsFromTxidRequestProto, GetEditsFromTxidResponseProto, ListOpenFilesRequestProto, OpenFilesBatchResponseProto, ListOpenFilesResponseProto, MsyncRequestProto, MsyncResponseProto, HAServiceStateRequestProto, HAServiceStateResponseProto, ClientNamenodeProtocol, ClientNamenodeProtocolStub, ClientNamenodeProtocolBlockingStub, getBlockLocations, getServerDefaults, create, append, setReplication, setStoragePolicy, unsetStoragePolicy, getStoragePolicy, getStoragePolicies, setPermission, setOwner, abandonBlock, addBlock, getAdditionalDatanode, complete, reportBadBlocks, concat, truncate, rename, rename2, delete, mkdirs, getListing, renewLease, recoverLease, getFsStats, getDatanodeReport, getDatanodeStorageReport, getPreferredBlockSize, setSafeMode, saveNamespace, rollEdits, restoreFailedStorage, refreshNodes, finalizeUpgrade, rollingUpgrade, listCorruptFileBlocks, metaSave, getFileInfo, addCacheDirective, modifyCacheDirective, removeCacheDirective, listCacheDirectives, addCachePool, modifyCachePool, removeCachePool, listCachePools, getFileLinkInfo, getContentSummary, setQuota, fsync, setTimes, createSymlink, getLinkTarget, updateBlockForPipeline, updatePipeline, getDelegationToken, renewDelegationToken, cancelDelegationToken, setBalancerBandwidth, getDataEncryptionKey, createSnapshot, renameSnapshot, allowSnapshot, disallowSnapshot, getSnapshottableDirListing, deleteSnapshot, getSnapshotDiffReport, isFileClosed, modifyAclEntries, removeAclEntries, removeDefaultAcl, removeAcl, setAcl, getAclStatus, setXAttr, getXAttrs, listXAttrs, removeXAttr, checkAccess, createEncryptionZone, listEncryptionZones, getEZForPath, getCurrentEditLogTxid, getEditsFromTxid, getQuotaUsage, listOpenFiles, msync, getHAServiceState

--- a/src/hadoop/HAServiceProtocol_pb.jl
+++ b/src/hadoop/HAServiceProtocol_pb.jl
@@ -1,0 +1,121 @@
+# syntax: proto2
+using ProtoBuf
+import ProtoBuf.meta
+import ..hadoop
+
+struct __enum_HAServiceStateProto <: ProtoEnum
+    INITIALIZING::Int32
+    ACTIVE::Int32
+    STANDBY::Int32
+    OBSERVER::Int32
+    __enum_HAServiceStateProto() = new(0,1,2,3)
+end #struct __enum_HAServiceStateProto
+const HAServiceStateProto = __enum_HAServiceStateProto()
+
+struct __enum_HARequestSource <: ProtoEnum
+    REQUEST_BY_USER::Int32
+    REQUEST_BY_USER_FORCED::Int32
+    REQUEST_BY_ZKFC::Int32
+    __enum_HARequestSource() = new(0,1,2)
+end #struct __enum_HARequestSource
+const HARequestSource = __enum_HARequestSource()
+
+mutable struct HAStateChangeRequestInfoProto <: ProtoType
+    reqSource::Int32
+    HAStateChangeRequestInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct HAStateChangeRequestInfoProto
+const __req_HAStateChangeRequestInfoProto = Symbol[:reqSource]
+meta(t::Type{HAStateChangeRequestInfoProto}) = meta(t, __req_HAStateChangeRequestInfoProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct MonitorHealthRequestProto <: ProtoType
+    MonitorHealthRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct MonitorHealthRequestProto
+
+mutable struct MonitorHealthResponseProto <: ProtoType
+    MonitorHealthResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct MonitorHealthResponseProto
+
+mutable struct TransitionToActiveRequestProto <: ProtoType
+    reqInfo::HAStateChangeRequestInfoProto
+    TransitionToActiveRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToActiveRequestProto
+const __req_TransitionToActiveRequestProto = Symbol[:reqInfo]
+meta(t::Type{TransitionToActiveRequestProto}) = meta(t, __req_TransitionToActiveRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct TransitionToActiveResponseProto <: ProtoType
+    TransitionToActiveResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToActiveResponseProto
+
+mutable struct TransitionToStandbyRequestProto <: ProtoType
+    reqInfo::HAStateChangeRequestInfoProto
+    TransitionToStandbyRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToStandbyRequestProto
+const __req_TransitionToStandbyRequestProto = Symbol[:reqInfo]
+meta(t::Type{TransitionToStandbyRequestProto}) = meta(t, __req_TransitionToStandbyRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct TransitionToStandbyResponseProto <: ProtoType
+    TransitionToStandbyResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToStandbyResponseProto
+
+mutable struct TransitionToObserverRequestProto <: ProtoType
+    reqInfo::HAStateChangeRequestInfoProto
+    TransitionToObserverRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToObserverRequestProto
+const __req_TransitionToObserverRequestProto = Symbol[:reqInfo]
+meta(t::Type{TransitionToObserverRequestProto}) = meta(t, __req_TransitionToObserverRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct TransitionToObserverResponseProto <: ProtoType
+    TransitionToObserverResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TransitionToObserverResponseProto
+
+mutable struct GetServiceStatusRequestProto <: ProtoType
+    GetServiceStatusRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetServiceStatusRequestProto
+
+mutable struct GetServiceStatusResponseProto <: ProtoType
+    state::Int32
+    readyToBecomeActive::Bool
+    notReadyReason::AbstractString
+    GetServiceStatusResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetServiceStatusResponseProto
+const __req_GetServiceStatusResponseProto = Symbol[:state]
+meta(t::Type{GetServiceStatusResponseProto}) = meta(t, __req_GetServiceStatusResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+# service methods for HAServiceProtocolService
+const _HAServiceProtocolService_methods = MethodDescriptor[
+        MethodDescriptor("monitorHealth", 1, hadoop.common.MonitorHealthRequestProto, hadoop.common.MonitorHealthResponseProto),
+        MethodDescriptor("transitionToActive", 2, hadoop.common.TransitionToActiveRequestProto, hadoop.common.TransitionToActiveResponseProto),
+        MethodDescriptor("transitionToStandby", 3, hadoop.common.TransitionToStandbyRequestProto, hadoop.common.TransitionToStandbyResponseProto),
+        MethodDescriptor("transitionToObserver", 4, hadoop.common.TransitionToObserverRequestProto, hadoop.common.TransitionToObserverResponseProto),
+        MethodDescriptor("getServiceStatus", 5, hadoop.common.GetServiceStatusRequestProto, hadoop.common.GetServiceStatusResponseProto)
+    ] # const _HAServiceProtocolService_methods
+const _HAServiceProtocolService_desc = ServiceDescriptor("hadoop.common.HAServiceProtocolService", 1, _HAServiceProtocolService_methods)
+
+HAServiceProtocolService(impl::Module) = ProtoService(_HAServiceProtocolService_desc, impl)
+
+mutable struct HAServiceProtocolServiceStub <: AbstractProtoServiceStub{false}
+    impl::ProtoServiceStub
+    HAServiceProtocolServiceStub(channel::ProtoRpcChannel) = new(ProtoServiceStub(_HAServiceProtocolService_desc, channel))
+end # mutable struct HAServiceProtocolServiceStub
+
+mutable struct HAServiceProtocolServiceBlockingStub <: AbstractProtoServiceStub{true}
+    impl::ProtoServiceBlockingStub
+    HAServiceProtocolServiceBlockingStub(channel::ProtoRpcChannel) = new(ProtoServiceBlockingStub(_HAServiceProtocolService_desc, channel))
+end # mutable struct HAServiceProtocolServiceBlockingStub
+
+monitorHealth(stub::HAServiceProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.MonitorHealthRequestProto, done::Function) = call_method(stub.impl, _HAServiceProtocolService_methods[1], controller, inp, done)
+monitorHealth(stub::HAServiceProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.MonitorHealthRequestProto) = call_method(stub.impl, _HAServiceProtocolService_methods[1], controller, inp)
+
+transitionToActive(stub::HAServiceProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToActiveRequestProto, done::Function) = call_method(stub.impl, _HAServiceProtocolService_methods[2], controller, inp, done)
+transitionToActive(stub::HAServiceProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToActiveRequestProto) = call_method(stub.impl, _HAServiceProtocolService_methods[2], controller, inp)
+
+transitionToStandby(stub::HAServiceProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToStandbyRequestProto, done::Function) = call_method(stub.impl, _HAServiceProtocolService_methods[3], controller, inp, done)
+transitionToStandby(stub::HAServiceProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToStandbyRequestProto) = call_method(stub.impl, _HAServiceProtocolService_methods[3], controller, inp)
+
+transitionToObserver(stub::HAServiceProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToObserverRequestProto, done::Function) = call_method(stub.impl, _HAServiceProtocolService_methods[4], controller, inp, done)
+transitionToObserver(stub::HAServiceProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.TransitionToObserverRequestProto) = call_method(stub.impl, _HAServiceProtocolService_methods[4], controller, inp)
+
+getServiceStatus(stub::HAServiceProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.GetServiceStatusRequestProto, done::Function) = call_method(stub.impl, _HAServiceProtocolService_methods[5], controller, inp, done)
+getServiceStatus(stub::HAServiceProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.GetServiceStatusRequestProto) = call_method(stub.impl, _HAServiceProtocolService_methods[5], controller, inp)
+
+export HAServiceStateProto, HARequestSource, HAStateChangeRequestInfoProto, MonitorHealthRequestProto, MonitorHealthResponseProto, TransitionToActiveRequestProto, TransitionToActiveResponseProto, TransitionToStandbyRequestProto, TransitionToStandbyResponseProto, TransitionToObserverRequestProto, TransitionToObserverResponseProto, GetServiceStatusRequestProto, GetServiceStatusResponseProto, HAServiceProtocolService, HAServiceProtocolServiceStub, HAServiceProtocolServiceBlockingStub, monitorHealth, transitionToActive, transitionToStandby, transitionToObserver, getServiceStatus

--- a/src/hadoop/RpcHeader_pb.jl
+++ b/src/hadoop/RpcHeader_pb.jl
@@ -16,6 +16,14 @@ mutable struct RPCTraceInfoProto <: ProtoType
     RPCTraceInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RPCTraceInfoProto
 
+mutable struct RPCCallerContextProto <: ProtoType
+    context::AbstractString
+    signature::Array{UInt8,1}
+    RPCCallerContextProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct RPCCallerContextProto
+const __req_RPCCallerContextProto = Symbol[:context]
+meta(t::Type{RPCCallerContextProto}) = meta(t, __req_RPCCallerContextProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 struct __enum_RpcRequestHeaderProto_OperationProto <: ProtoEnum
     RPC_FINAL_PACKET::Int32
     RPC_CONTINUATION_PACKET::Int32
@@ -31,6 +39,8 @@ mutable struct RpcRequestHeaderProto <: ProtoType
     clientId::Array{UInt8,1}
     retryCount::Int32
     traceInfo::RPCTraceInfoProto
+    callerContext::RPCCallerContextProto
+    stateId::Int64
     RpcRequestHeaderProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RpcRequestHeaderProto
 const __req_RpcRequestHeaderProto = Symbol[:callId,:clientId]
@@ -72,6 +82,7 @@ mutable struct RpcResponseHeaderProto <: ProtoType
     errorDetail::Int32
     clientId::Array{UInt8,1}
     retryCount::Int32
+    stateId::Int64
     RpcResponseHeaderProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RpcResponseHeaderProto
 const __req_RpcResponseHeaderProto = Symbol[:callId,:status]
@@ -111,4 +122,4 @@ end #mutable struct RpcSaslProto
 const __req_RpcSaslProto = Symbol[:state]
 meta(t::Type{RpcSaslProto}) = meta(t, __req_RpcSaslProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export RpcKindProto, RPCTraceInfoProto, RpcRequestHeaderProto_OperationProto, RpcRequestHeaderProto, RpcResponseHeaderProto_RpcStatusProto, RpcResponseHeaderProto_RpcErrorCodeProto, RpcResponseHeaderProto, RpcSaslProto_SaslState, RpcSaslProto_SaslAuth, RpcSaslProto
+export RpcKindProto, RPCTraceInfoProto, RPCCallerContextProto, RpcRequestHeaderProto_OperationProto, RpcRequestHeaderProto, RpcResponseHeaderProto_RpcStatusProto, RpcResponseHeaderProto_RpcErrorCodeProto, RpcResponseHeaderProto, RpcSaslProto_SaslState, RpcSaslProto_SaslAuth, RpcSaslProto

--- a/src/hadoop/acl_pb.jl
+++ b/src/hadoop/acl_pb.jl
@@ -52,14 +52,6 @@ end #mutable struct AclStatusProto
 const __req_AclStatusProto = Symbol[:owner,:group,:sticky]
 meta(t::Type{AclStatusProto}) = meta(t, __req_AclStatusProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-mutable struct AclEditLogProto <: ProtoType
-    src::AbstractString
-    entries::Base.Vector{AclEntryProto}
-    AclEditLogProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct AclEditLogProto
-const __req_AclEditLogProto = Symbol[:src]
-meta(t::Type{AclEditLogProto}) = meta(t, __req_AclEditLogProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
 mutable struct ModifyAclEntriesRequestProto <: ProtoType
     src::AbstractString
     aclSpec::Base.Vector{AclEntryProto}
@@ -132,4 +124,4 @@ end #mutable struct GetAclStatusResponseProto
 const __req_GetAclStatusResponseProto = Symbol[:result]
 meta(t::Type{GetAclStatusResponseProto}) = meta(t, __req_GetAclStatusResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export AclEntryProto_AclEntryScopeProto, AclEntryProto_AclEntryTypeProto, AclEntryProto_FsActionProto, AclEntryProto, AclStatusProto, AclEditLogProto, ModifyAclEntriesRequestProto, ModifyAclEntriesResponseProto, RemoveAclRequestProto, RemoveAclResponseProto, RemoveAclEntriesRequestProto, RemoveAclEntriesResponseProto, RemoveDefaultAclRequestProto, RemoveDefaultAclResponseProto, SetAclRequestProto, SetAclResponseProto, GetAclStatusRequestProto, GetAclStatusResponseProto
+export AclEntryProto_AclEntryScopeProto, AclEntryProto_AclEntryTypeProto, AclEntryProto_FsActionProto, AclEntryProto, AclStatusProto, ModifyAclEntriesRequestProto, ModifyAclEntriesResponseProto, RemoveAclRequestProto, RemoveAclResponseProto, RemoveAclEntriesRequestProto, RemoveAclEntriesResponseProto, RemoveDefaultAclRequestProto, RemoveDefaultAclResponseProto, SetAclRequestProto, SetAclResponseProto, GetAclStatusRequestProto, GetAclStatusResponseProto

--- a/src/hadoop/applicationclient_protocol_pb.jl
+++ b/src/hadoop/applicationclient_protocol_pb.jl
@@ -8,26 +8,33 @@ const _ApplicationClientProtocolService_methods = MethodDescriptor[
         MethodDescriptor("getNewApplication", 1, hadoop.yarn.GetNewApplicationRequestProto, hadoop.yarn.GetNewApplicationResponseProto),
         MethodDescriptor("getApplicationReport", 2, hadoop.yarn.GetApplicationReportRequestProto, hadoop.yarn.GetApplicationReportResponseProto),
         MethodDescriptor("submitApplication", 3, hadoop.yarn.SubmitApplicationRequestProto, hadoop.yarn.SubmitApplicationResponseProto),
-        MethodDescriptor("forceKillApplication", 4, hadoop.yarn.KillApplicationRequestProto, hadoop.yarn.KillApplicationResponseProto),
-        MethodDescriptor("getClusterMetrics", 5, hadoop.yarn.GetClusterMetricsRequestProto, hadoop.yarn.GetClusterMetricsResponseProto),
-        MethodDescriptor("getApplications", 6, hadoop.yarn.GetApplicationsRequestProto, hadoop.yarn.GetApplicationsResponseProto),
-        MethodDescriptor("getClusterNodes", 7, hadoop.yarn.GetClusterNodesRequestProto, hadoop.yarn.GetClusterNodesResponseProto),
-        MethodDescriptor("getQueueInfo", 8, hadoop.yarn.GetQueueInfoRequestProto, hadoop.yarn.GetQueueInfoResponseProto),
-        MethodDescriptor("getQueueUserAcls", 9, hadoop.yarn.GetQueueUserAclsInfoRequestProto, hadoop.yarn.GetQueueUserAclsInfoResponseProto),
-        MethodDescriptor("getDelegationToken", 10, hadoop.common.GetDelegationTokenRequestProto, hadoop.common.GetDelegationTokenResponseProto),
-        MethodDescriptor("renewDelegationToken", 11, hadoop.common.RenewDelegationTokenRequestProto, hadoop.common.RenewDelegationTokenResponseProto),
-        MethodDescriptor("cancelDelegationToken", 12, hadoop.common.CancelDelegationTokenRequestProto, hadoop.common.CancelDelegationTokenResponseProto),
-        MethodDescriptor("moveApplicationAcrossQueues", 13, hadoop.yarn.MoveApplicationAcrossQueuesRequestProto, hadoop.yarn.MoveApplicationAcrossQueuesResponseProto),
-        MethodDescriptor("getApplicationAttemptReport", 14, hadoop.yarn.GetApplicationAttemptReportRequestProto, hadoop.yarn.GetApplicationAttemptReportResponseProto),
-        MethodDescriptor("getApplicationAttempts", 15, hadoop.yarn.GetApplicationAttemptsRequestProto, hadoop.yarn.GetApplicationAttemptsResponseProto),
-        MethodDescriptor("getContainerReport", 16, hadoop.yarn.GetContainerReportRequestProto, hadoop.yarn.GetContainerReportResponseProto),
-        MethodDescriptor("getContainers", 17, hadoop.yarn.GetContainersRequestProto, hadoop.yarn.GetContainersResponseProto),
-        MethodDescriptor("submitReservation", 18, hadoop.yarn.ReservationSubmissionRequestProto, hadoop.yarn.ReservationSubmissionResponseProto),
-        MethodDescriptor("updateReservation", 19, hadoop.yarn.ReservationUpdateRequestProto, hadoop.yarn.ReservationUpdateResponseProto),
-        MethodDescriptor("deleteReservation", 20, hadoop.yarn.ReservationDeleteRequestProto, hadoop.yarn.ReservationDeleteResponseProto),
-        MethodDescriptor("getNodeToLabels", 21, hadoop.yarn.GetNodesToLabelsRequestProto, hadoop.yarn.GetNodesToLabelsResponseProto),
-        MethodDescriptor("getLabelsToNodes", 22, hadoop.yarn.GetLabelsToNodesRequestProto, hadoop.yarn.GetLabelsToNodesResponseProto),
-        MethodDescriptor("getClusterNodeLabels", 23, hadoop.yarn.GetClusterNodeLabelsRequestProto, hadoop.yarn.GetClusterNodeLabelsResponseProto)
+        MethodDescriptor("failApplicationAttempt", 4, hadoop.yarn.FailApplicationAttemptRequestProto, hadoop.yarn.FailApplicationAttemptResponseProto),
+        MethodDescriptor("forceKillApplication", 5, hadoop.yarn.KillApplicationRequestProto, hadoop.yarn.KillApplicationResponseProto),
+        MethodDescriptor("getClusterMetrics", 6, hadoop.yarn.GetClusterMetricsRequestProto, hadoop.yarn.GetClusterMetricsResponseProto),
+        MethodDescriptor("getApplications", 7, hadoop.yarn.GetApplicationsRequestProto, hadoop.yarn.GetApplicationsResponseProto),
+        MethodDescriptor("getClusterNodes", 8, hadoop.yarn.GetClusterNodesRequestProto, hadoop.yarn.GetClusterNodesResponseProto),
+        MethodDescriptor("getQueueInfo", 9, hadoop.yarn.GetQueueInfoRequestProto, hadoop.yarn.GetQueueInfoResponseProto),
+        MethodDescriptor("getQueueUserAcls", 10, hadoop.yarn.GetQueueUserAclsInfoRequestProto, hadoop.yarn.GetQueueUserAclsInfoResponseProto),
+        MethodDescriptor("getDelegationToken", 11, hadoop.common.GetDelegationTokenRequestProto, hadoop.common.GetDelegationTokenResponseProto),
+        MethodDescriptor("renewDelegationToken", 12, hadoop.common.RenewDelegationTokenRequestProto, hadoop.common.RenewDelegationTokenResponseProto),
+        MethodDescriptor("cancelDelegationToken", 13, hadoop.common.CancelDelegationTokenRequestProto, hadoop.common.CancelDelegationTokenResponseProto),
+        MethodDescriptor("moveApplicationAcrossQueues", 14, hadoop.yarn.MoveApplicationAcrossQueuesRequestProto, hadoop.yarn.MoveApplicationAcrossQueuesResponseProto),
+        MethodDescriptor("getApplicationAttemptReport", 15, hadoop.yarn.GetApplicationAttemptReportRequestProto, hadoop.yarn.GetApplicationAttemptReportResponseProto),
+        MethodDescriptor("getApplicationAttempts", 16, hadoop.yarn.GetApplicationAttemptsRequestProto, hadoop.yarn.GetApplicationAttemptsResponseProto),
+        MethodDescriptor("getContainerReport", 17, hadoop.yarn.GetContainerReportRequestProto, hadoop.yarn.GetContainerReportResponseProto),
+        MethodDescriptor("getContainers", 18, hadoop.yarn.GetContainersRequestProto, hadoop.yarn.GetContainersResponseProto),
+        MethodDescriptor("getNewReservation", 19, hadoop.yarn.GetNewReservationRequestProto, hadoop.yarn.GetNewReservationResponseProto),
+        MethodDescriptor("submitReservation", 20, hadoop.yarn.ReservationSubmissionRequestProto, hadoop.yarn.ReservationSubmissionResponseProto),
+        MethodDescriptor("updateReservation", 21, hadoop.yarn.ReservationUpdateRequestProto, hadoop.yarn.ReservationUpdateResponseProto),
+        MethodDescriptor("deleteReservation", 22, hadoop.yarn.ReservationDeleteRequestProto, hadoop.yarn.ReservationDeleteResponseProto),
+        MethodDescriptor("listReservations", 23, hadoop.yarn.ReservationListRequestProto, hadoop.yarn.ReservationListResponseProto),
+        MethodDescriptor("getNodeToLabels", 24, hadoop.yarn.GetNodesToLabelsRequestProto, hadoop.yarn.GetNodesToLabelsResponseProto),
+        MethodDescriptor("getLabelsToNodes", 25, hadoop.yarn.GetLabelsToNodesRequestProto, hadoop.yarn.GetLabelsToNodesResponseProto),
+        MethodDescriptor("getClusterNodeLabels", 26, hadoop.yarn.GetClusterNodeLabelsRequestProto, hadoop.yarn.GetClusterNodeLabelsResponseProto),
+        MethodDescriptor("updateApplicationPriority", 27, hadoop.yarn.UpdateApplicationPriorityRequestProto, hadoop.yarn.UpdateApplicationPriorityResponseProto),
+        MethodDescriptor("signalToContainer", 28, hadoop.yarn.SignalContainerRequestProto, hadoop.yarn.SignalContainerResponseProto),
+        MethodDescriptor("updateApplicationTimeouts", 29, hadoop.yarn.UpdateApplicationTimeoutsRequestProto, hadoop.yarn.UpdateApplicationTimeoutsResponseProto),
+        MethodDescriptor("getResourceTypeInfo", 30, hadoop.yarn.GetAllResourceTypeInfoRequestProto, hadoop.yarn.GetAllResourceTypeInfoResponseProto)
     ] # const _ApplicationClientProtocolService_methods
 const _ApplicationClientProtocolService_desc = ServiceDescriptor("hadoop.yarn.ApplicationClientProtocolService", 1, _ApplicationClientProtocolService_methods)
 
@@ -52,64 +59,85 @@ getApplicationReport(stub::ApplicationClientProtocolServiceBlockingStub, control
 submitApplication(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.SubmitApplicationRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[3], controller, inp, done)
 submitApplication(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.SubmitApplicationRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[3], controller, inp)
 
-forceKillApplication(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.KillApplicationRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[4], controller, inp, done)
-forceKillApplication(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.KillApplicationRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[4], controller, inp)
+failApplicationAttempt(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.FailApplicationAttemptRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[4], controller, inp, done)
+failApplicationAttempt(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.FailApplicationAttemptRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[4], controller, inp)
 
-getClusterMetrics(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterMetricsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[5], controller, inp, done)
-getClusterMetrics(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterMetricsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[5], controller, inp)
+forceKillApplication(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.KillApplicationRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[5], controller, inp, done)
+forceKillApplication(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.KillApplicationRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[5], controller, inp)
 
-getApplications(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[6], controller, inp, done)
-getApplications(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[6], controller, inp)
+getClusterMetrics(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterMetricsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[6], controller, inp, done)
+getClusterMetrics(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterMetricsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[6], controller, inp)
 
-getClusterNodes(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[7], controller, inp, done)
-getClusterNodes(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[7], controller, inp)
+getApplications(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[7], controller, inp, done)
+getApplications(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[7], controller, inp)
 
-getQueueInfo(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueInfoRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[8], controller, inp, done)
-getQueueInfo(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueInfoRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[8], controller, inp)
+getClusterNodes(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[8], controller, inp, done)
+getClusterNodes(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[8], controller, inp)
 
-getQueueUserAcls(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueUserAclsInfoRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[9], controller, inp, done)
-getQueueUserAcls(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueUserAclsInfoRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[9], controller, inp)
+getQueueInfo(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueInfoRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[9], controller, inp, done)
+getQueueInfo(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueInfoRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[9], controller, inp)
 
-getDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[10], controller, inp, done)
-getDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[10], controller, inp)
+getQueueUserAcls(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueUserAclsInfoRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[10], controller, inp, done)
+getQueueUserAcls(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetQueueUserAclsInfoRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[10], controller, inp)
 
-renewDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[11], controller, inp, done)
-renewDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[11], controller, inp)
+getDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[11], controller, inp, done)
+getDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.GetDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[11], controller, inp)
 
-cancelDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[12], controller, inp, done)
-cancelDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[12], controller, inp)
+renewDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[12], controller, inp, done)
+renewDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.RenewDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[12], controller, inp)
 
-moveApplicationAcrossQueues(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.MoveApplicationAcrossQueuesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[13], controller, inp, done)
-moveApplicationAcrossQueues(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.MoveApplicationAcrossQueuesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[13], controller, inp)
+cancelDelegationToken(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[13], controller, inp, done)
+cancelDelegationToken(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.common.CancelDelegationTokenRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[13], controller, inp)
 
-getApplicationAttemptReport(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptReportRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[14], controller, inp, done)
-getApplicationAttemptReport(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptReportRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[14], controller, inp)
+moveApplicationAcrossQueues(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.MoveApplicationAcrossQueuesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[14], controller, inp, done)
+moveApplicationAcrossQueues(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.MoveApplicationAcrossQueuesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[14], controller, inp)
 
-getApplicationAttempts(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[15], controller, inp, done)
-getApplicationAttempts(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[15], controller, inp)
+getApplicationAttemptReport(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptReportRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[15], controller, inp, done)
+getApplicationAttemptReport(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptReportRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[15], controller, inp)
 
-getContainerReport(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerReportRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[16], controller, inp, done)
-getContainerReport(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerReportRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[16], controller, inp)
+getApplicationAttempts(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[16], controller, inp, done)
+getApplicationAttempts(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetApplicationAttemptsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[16], controller, inp)
 
-getContainers(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainersRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[17], controller, inp, done)
-getContainers(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainersRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[17], controller, inp)
+getContainerReport(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerReportRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[17], controller, inp, done)
+getContainerReport(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerReportRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[17], controller, inp)
 
-submitReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationSubmissionRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[18], controller, inp, done)
-submitReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationSubmissionRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[18], controller, inp)
+getContainers(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainersRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[18], controller, inp, done)
+getContainers(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainersRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[18], controller, inp)
 
-updateReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationUpdateRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[19], controller, inp, done)
-updateReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationUpdateRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[19], controller, inp)
+getNewReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNewReservationRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[19], controller, inp, done)
+getNewReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNewReservationRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[19], controller, inp)
 
-deleteReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationDeleteRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[20], controller, inp, done)
-deleteReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationDeleteRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[20], controller, inp)
+submitReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationSubmissionRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[20], controller, inp, done)
+submitReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationSubmissionRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[20], controller, inp)
 
-getNodeToLabels(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNodesToLabelsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[21], controller, inp, done)
-getNodeToLabels(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNodesToLabelsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[21], controller, inp)
+updateReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationUpdateRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[21], controller, inp, done)
+updateReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationUpdateRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[21], controller, inp)
 
-getLabelsToNodes(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetLabelsToNodesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[22], controller, inp, done)
-getLabelsToNodes(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetLabelsToNodesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[22], controller, inp)
+deleteReservation(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationDeleteRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[22], controller, inp, done)
+deleteReservation(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationDeleteRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[22], controller, inp)
 
-getClusterNodeLabels(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodeLabelsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[23], controller, inp, done)
-getClusterNodeLabels(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodeLabelsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[23], controller, inp)
+listReservations(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationListRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[23], controller, inp, done)
+listReservations(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReservationListRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[23], controller, inp)
 
-export ApplicationClientProtocolService, ApplicationClientProtocolServiceStub, ApplicationClientProtocolServiceBlockingStub, getNewApplication, getApplicationReport, submitApplication, forceKillApplication, getClusterMetrics, getApplications, getClusterNodes, getQueueInfo, getQueueUserAcls, getDelegationToken, renewDelegationToken, cancelDelegationToken, moveApplicationAcrossQueues, getApplicationAttemptReport, getApplicationAttempts, getContainerReport, getContainers, submitReservation, updateReservation, deleteReservation, getNodeToLabels, getLabelsToNodes, getClusterNodeLabels
+getNodeToLabels(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNodesToLabelsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[24], controller, inp, done)
+getNodeToLabels(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetNodesToLabelsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[24], controller, inp)
+
+getLabelsToNodes(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetLabelsToNodesRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[25], controller, inp, done)
+getLabelsToNodes(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetLabelsToNodesRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[25], controller, inp)
+
+getClusterNodeLabels(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodeLabelsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[26], controller, inp, done)
+getClusterNodeLabels(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetClusterNodeLabelsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[26], controller, inp)
+
+updateApplicationPriority(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.UpdateApplicationPriorityRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[27], controller, inp, done)
+updateApplicationPriority(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.UpdateApplicationPriorityRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[27], controller, inp)
+
+signalToContainer(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.SignalContainerRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[28], controller, inp, done)
+signalToContainer(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.SignalContainerRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[28], controller, inp)
+
+updateApplicationTimeouts(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.UpdateApplicationTimeoutsRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[29], controller, inp, done)
+updateApplicationTimeouts(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.UpdateApplicationTimeoutsRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[29], controller, inp)
+
+getResourceTypeInfo(stub::ApplicationClientProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetAllResourceTypeInfoRequestProto, done::Function) = call_method(stub.impl, _ApplicationClientProtocolService_methods[30], controller, inp, done)
+getResourceTypeInfo(stub::ApplicationClientProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetAllResourceTypeInfoRequestProto) = call_method(stub.impl, _ApplicationClientProtocolService_methods[30], controller, inp)
+
+export ApplicationClientProtocolService, ApplicationClientProtocolServiceStub, ApplicationClientProtocolServiceBlockingStub, getNewApplication, getApplicationReport, submitApplication, failApplicationAttempt, forceKillApplication, getClusterMetrics, getApplications, getClusterNodes, getQueueInfo, getQueueUserAcls, getDelegationToken, renewDelegationToken, cancelDelegationToken, moveApplicationAcrossQueues, getApplicationAttemptReport, getApplicationAttempts, getContainerReport, getContainers, getNewReservation, submitReservation, updateReservation, deleteReservation, listReservations, getNodeToLabels, getLabelsToNodes, getClusterNodeLabels, updateApplicationPriority, signalToContainer, updateApplicationTimeouts, getResourceTypeInfo

--- a/src/hadoop/containermanagement_protocol_pb.jl
+++ b/src/hadoop/containermanagement_protocol_pb.jl
@@ -6,7 +6,15 @@ import ProtoBuf.meta
 const _ContainerManagementProtocolService_methods = MethodDescriptor[
         MethodDescriptor("startContainers", 1, hadoop.yarn.StartContainersRequestProto, hadoop.yarn.StartContainersResponseProto),
         MethodDescriptor("stopContainers", 2, hadoop.yarn.StopContainersRequestProto, hadoop.yarn.StopContainersResponseProto),
-        MethodDescriptor("getContainerStatuses", 3, hadoop.yarn.GetContainerStatusesRequestProto, hadoop.yarn.GetContainerStatusesResponseProto)
+        MethodDescriptor("getContainerStatuses", 3, hadoop.yarn.GetContainerStatusesRequestProto, hadoop.yarn.GetContainerStatusesResponseProto),
+        MethodDescriptor("increaseContainersResource", 4, hadoop.yarn.IncreaseContainersResourceRequestProto, hadoop.yarn.IncreaseContainersResourceResponseProto),
+        MethodDescriptor("updateContainer", 5, hadoop.yarn.ContainerUpdateRequestProto, hadoop.yarn.ContainerUpdateResponseProto),
+        MethodDescriptor("signalToContainer", 6, hadoop.yarn.SignalContainerRequestProto, hadoop.yarn.SignalContainerResponseProto),
+        MethodDescriptor("localize", 7, hadoop.yarn.ResourceLocalizationRequestProto, hadoop.yarn.ResourceLocalizationResponseProto),
+        MethodDescriptor("reInitializeContainer", 8, hadoop.yarn.ReInitializeContainerRequestProto, hadoop.yarn.ReInitializeContainerResponseProto),
+        MethodDescriptor("restartContainer", 9, hadoop.yarn.ContainerIdProto, hadoop.yarn.RestartContainerResponseProto),
+        MethodDescriptor("rollbackLastReInitialization", 10, hadoop.yarn.ContainerIdProto, hadoop.yarn.RollbackResponseProto),
+        MethodDescriptor("commitLastReInitialization", 11, hadoop.yarn.ContainerIdProto, hadoop.yarn.CommitResponseProto)
     ] # const _ContainerManagementProtocolService_methods
 const _ContainerManagementProtocolService_desc = ServiceDescriptor("hadoop.yarn.ContainerManagementProtocolService", 1, _ContainerManagementProtocolService_methods)
 
@@ -31,4 +39,28 @@ stopContainers(stub::ContainerManagementProtocolServiceBlockingStub, controller:
 getContainerStatuses(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerStatusesRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[3], controller, inp, done)
 getContainerStatuses(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.GetContainerStatusesRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[3], controller, inp)
 
-export ContainerManagementProtocolService, ContainerManagementProtocolServiceStub, ContainerManagementProtocolServiceBlockingStub, startContainers, stopContainers, getContainerStatuses
+increaseContainersResource(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.IncreaseContainersResourceRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[4], controller, inp, done)
+increaseContainersResource(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.IncreaseContainersResourceRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[4], controller, inp)
+
+updateContainer(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerUpdateRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[5], controller, inp, done)
+updateContainer(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerUpdateRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[5], controller, inp)
+
+signalToContainer(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.SignalContainerRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[6], controller, inp, done)
+signalToContainer(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.SignalContainerRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[6], controller, inp)
+
+localize(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ResourceLocalizationRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[7], controller, inp, done)
+localize(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ResourceLocalizationRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[7], controller, inp)
+
+reInitializeContainer(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ReInitializeContainerRequestProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[8], controller, inp, done)
+reInitializeContainer(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ReInitializeContainerRequestProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[8], controller, inp)
+
+restartContainer(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[9], controller, inp, done)
+restartContainer(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[9], controller, inp)
+
+rollbackLastReInitialization(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[10], controller, inp, done)
+rollbackLastReInitialization(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[10], controller, inp)
+
+commitLastReInitialization(stub::ContainerManagementProtocolServiceStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto, done::Function) = call_method(stub.impl, _ContainerManagementProtocolService_methods[11], controller, inp, done)
+commitLastReInitialization(stub::ContainerManagementProtocolServiceBlockingStub, controller::ProtoRpcController, inp::hadoop.yarn.ContainerIdProto) = call_method(stub.impl, _ContainerManagementProtocolService_methods[11], controller, inp)
+
+export ContainerManagementProtocolService, ContainerManagementProtocolServiceStub, ContainerManagementProtocolServiceBlockingStub, startContainers, stopContainers, getContainerStatuses, increaseContainersResource, updateContainer, signalToContainer, localize, reInitializeContainer, restartContainer, rollbackLastReInitialization, commitLastReInitialization

--- a/src/hadoop/datatransfer_pb.jl
+++ b/src/hadoop/datatransfer_pb.jl
@@ -28,6 +28,14 @@ struct __enum_ShortCircuitFdResponse <: ProtoEnum
 end #struct __enum_ShortCircuitFdResponse
 const ShortCircuitFdResponse = __enum_ShortCircuitFdResponse()
 
+mutable struct HandshakeSecretProto <: ProtoType
+    secret::Array{UInt8,1}
+    bpid::AbstractString
+    HandshakeSecretProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct HandshakeSecretProto
+const __req_HandshakeSecretProto = Symbol[:secret,:bpid]
+meta(t::Type{HandshakeSecretProto}) = meta(t, __req_HandshakeSecretProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 struct __enum_DataTransferEncryptorMessageProto_DataTransferEncryptorStatus <: ProtoEnum
     SUCCESS::Int32
     ERROR_UNKNOWN_KEY::Int32
@@ -41,6 +49,7 @@ mutable struct DataTransferEncryptorMessageProto <: ProtoType
     payload::Array{UInt8,1}
     message::AbstractString
     cipherOption::Base.Vector{CipherOptionProto}
+    handshakeSecret::HandshakeSecretProto
     DataTransferEncryptorMessageProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DataTransferEncryptorMessageProto
 const __req_DataTransferEncryptorMessageProto = Symbol[:status]
@@ -297,4 +306,11 @@ end #mutable struct BlockOpResponseProto
 const __req_BlockOpResponseProto = Symbol[:status]
 meta(t::Type{BlockOpResponseProto}) = meta(t, __req_BlockOpResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export Status, ShortCircuitFdResponse, DataTransferEncryptorMessageProto_DataTransferEncryptorStatus, DataTransferEncryptorMessageProto, BaseHeaderProto, DataTransferTraceInfoProto, ClientOperationHeaderProto, CachingStrategyProto, OpReadBlockProto, ChecksumProto, OpWriteBlockProto_BlockConstructionStage, OpWriteBlockProto, OpTransferBlockProto, OpReplaceBlockProto, OpCopyBlockProto, OpBlockChecksumProto, ShortCircuitShmIdProto, ShortCircuitShmSlotProto, OpRequestShortCircuitAccessProto, ReleaseShortCircuitAccessRequestProto, ReleaseShortCircuitAccessResponseProto, ShortCircuitShmRequestProto, ShortCircuitShmResponseProto, PacketHeaderProto, PipelineAckProto, ReadOpChecksumInfoProto, BlockOpResponseProto, ClientReadStatusProto, DNTransferAckProto, OpBlockChecksumResponseProto
+mutable struct OpCustomProto <: ProtoType
+    customId::AbstractString
+    OpCustomProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct OpCustomProto
+const __req_OpCustomProto = Symbol[:customId]
+meta(t::Type{OpCustomProto}) = meta(t, __req_OpCustomProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+export Status, ShortCircuitFdResponse, DataTransferEncryptorMessageProto_DataTransferEncryptorStatus, DataTransferEncryptorMessageProto, HandshakeSecretProto, BaseHeaderProto, DataTransferTraceInfoProto, ClientOperationHeaderProto, CachingStrategyProto, OpReadBlockProto, ChecksumProto, OpWriteBlockProto_BlockConstructionStage, OpWriteBlockProto, OpTransferBlockProto, OpReplaceBlockProto, OpCopyBlockProto, OpBlockChecksumProto, ShortCircuitShmIdProto, ShortCircuitShmSlotProto, OpRequestShortCircuitAccessProto, ReleaseShortCircuitAccessRequestProto, ReleaseShortCircuitAccessResponseProto, ShortCircuitShmRequestProto, ShortCircuitShmResponseProto, PacketHeaderProto, PipelineAckProto, ReadOpChecksumInfoProto, BlockOpResponseProto, ClientReadStatusProto, DNTransferAckProto, OpBlockChecksumResponseProto, OpCustomProto

--- a/src/hadoop/hadoop.jl
+++ b/src/hadoop/hadoop.jl
@@ -2,6 +2,7 @@ module hadoop
   const _ProtoBuf_Top_ = @static isdefined(parentmodule(@__MODULE__), :_ProtoBuf_Top_) ? (parentmodule(@__MODULE__))._ProtoBuf_Top_ : parentmodule(@__MODULE__)
   module common
     const _ProtoBuf_Top_ = @static isdefined(parentmodule(@__MODULE__), :_ProtoBuf_Top_) ? (parentmodule(@__MODULE__))._ProtoBuf_Top_ : parentmodule(@__MODULE__)
+    include("HAServiceProtocol_pb.jl")
     include("ProtobufRpcEngine_pb.jl")
     include("RpcHeader_pb.jl")
     include("Security_pb.jl")

--- a/src/hadoop/hdfs_pb.jl
+++ b/src/hadoop/hdfs_pb.jl
@@ -34,16 +34,6 @@ struct __enum_ChecksumTypeProto <: ProtoEnum
 end #struct __enum_ChecksumTypeProto
 const ChecksumTypeProto = __enum_ChecksumTypeProto()
 
-struct __enum_ReplicaStateProto <: ProtoEnum
-    FINALIZED::Int32
-    RBW::Int32
-    RWR::Int32
-    RUR::Int32
-    TEMPORARY::Int32
-    __enum_ReplicaStateProto() = new(0,1,2,3,4)
-end #struct __enum_ReplicaStateProto
-const ReplicaStateProto = __enum_ReplicaStateProto()
-
 mutable struct ExtendedBlockProto <: ProtoType
     poolId::AbstractString
     blockId::UInt64
@@ -78,11 +68,26 @@ end #mutable struct DatanodeLocalInfoProto
 const __req_DatanodeLocalInfoProto = Symbol[:softwareVersion,:configVersion,:uptime]
 meta(t::Type{DatanodeLocalInfoProto}) = meta(t, __req_DatanodeLocalInfoProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
+mutable struct DatanodeVolumeInfoProto <: ProtoType
+    path::AbstractString
+    storageType::Int32
+    usedSpace::UInt64
+    freeSpace::UInt64
+    reservedSpace::UInt64
+    reservedSpaceForReplicas::UInt64
+    numBlocks::UInt64
+    DatanodeVolumeInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct DatanodeVolumeInfoProto
+const __req_DatanodeVolumeInfoProto = Symbol[:path,:storageType,:usedSpace,:freeSpace,:reservedSpace,:reservedSpaceForReplicas,:numBlocks]
+meta(t::Type{DatanodeVolumeInfoProto}) = meta(t, __req_DatanodeVolumeInfoProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 struct __enum_DatanodeInfoProto_AdminState <: ProtoEnum
     NORMAL::Int32
     DECOMMISSION_INPROGRESS::Int32
     DECOMMISSIONED::Int32
-    __enum_DatanodeInfoProto_AdminState() = new(0,1,2)
+    ENTERING_MAINTENANCE::Int32
+    IN_MAINTENANCE::Int32
+    __enum_DatanodeInfoProto_AdminState() = new(0,1,2,3,4)
 end #struct __enum_DatanodeInfoProto_AdminState
 const DatanodeInfoProto_AdminState = __enum_DatanodeInfoProto_AdminState()
 
@@ -95,16 +100,19 @@ mutable struct DatanodeInfoProto <: ProtoType
     lastUpdate::UInt64
     xceiverCount::UInt32
     location::AbstractString
+    nonDfsUsed::UInt64
     adminState::Int32
     cacheCapacity::UInt64
     cacheUsed::UInt64
     lastUpdateMonotonic::UInt64
+    upgradeDomain::AbstractString
+    lastBlockReportTime::UInt64
+    lastBlockReportMonotonic::UInt64
     DatanodeInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DatanodeInfoProto
 const __req_DatanodeInfoProto = Symbol[:id]
-const __val_DatanodeInfoProto = Dict(:capacity => 0, :dfsUsed => 0, :remaining => 0, :blockPoolUsed => 0, :lastUpdate => 0, :xceiverCount => 0, :adminState => DatanodeInfoProto_AdminState.NORMAL, :cacheCapacity => 0, :cacheUsed => 0, :lastUpdateMonotonic => 0)
-const __fnum_DatanodeInfoProto = Int[1,2,3,4,5,6,7,8,10,11,12,13]
-meta(t::Type{DatanodeInfoProto}) = meta(t, __req_DatanodeInfoProto, __fnum_DatanodeInfoProto, __val_DatanodeInfoProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+const __val_DatanodeInfoProto = Dict(:capacity => 0, :dfsUsed => 0, :remaining => 0, :blockPoolUsed => 0, :lastUpdate => 0, :xceiverCount => 0, :adminState => DatanodeInfoProto_AdminState.NORMAL, :cacheCapacity => 0, :cacheUsed => 0, :lastUpdateMonotonic => 0, :lastBlockReportTime => 0, :lastBlockReportMonotonic => 0)
+meta(t::Type{DatanodeInfoProto}) = meta(t, __req_DatanodeInfoProto, ProtoBuf.DEF_FNUM, __val_DatanodeInfoProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct DatanodeInfosProto <: ProtoType
     datanodes::Base.Vector{DatanodeInfoProto}
@@ -136,6 +144,7 @@ mutable struct StorageReportProto <: ProtoType
     remaining::UInt64
     blockPoolUsed::UInt64
     storage::DatanodeStorageProto
+    nonDfsUsed::UInt64
     StorageReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct StorageReportProto
 const __req_StorageReportProto = Symbol[:storageUuid]
@@ -164,10 +173,25 @@ mutable struct ContentSummaryProto <: ProtoType
     spaceConsumed::UInt64
     spaceQuota::UInt64
     typeQuotaInfos::StorageTypeQuotaInfosProto
+    snapshotLength::UInt64
+    snapshotFileCount::UInt64
+    snapshotDirectoryCount::UInt64
+    snapshotSpaceConsumed::UInt64
     ContentSummaryProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ContentSummaryProto
 const __req_ContentSummaryProto = Symbol[:length,:fileCount,:directoryCount,:quota,:spaceConsumed,:spaceQuota]
 meta(t::Type{ContentSummaryProto}) = meta(t, __req_ContentSummaryProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct QuotaUsageProto <: ProtoType
+    fileAndDirectoryCount::UInt64
+    quota::UInt64
+    spaceConsumed::UInt64
+    spaceQuota::UInt64
+    typeQuotaInfos::StorageTypeQuotaInfosProto
+    QuotaUsageProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct QuotaUsageProto
+const __req_QuotaUsageProto = Symbol[:fileAndDirectoryCount,:quota,:spaceConsumed,:spaceQuota]
+meta(t::Type{QuotaUsageProto}) = meta(t, __req_QuotaUsageProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct CorruptFileBlocksProto <: ProtoType
     files::Base.Vector{AbstractString}
@@ -199,11 +223,6 @@ mutable struct BlockStoragePolicyProto <: ProtoType
 end #mutable struct BlockStoragePolicyProto
 const __req_BlockStoragePolicyProto = Symbol[:policyId,:name,:creationPolicy]
 meta(t::Type{BlockStoragePolicyProto}) = meta(t, __req_BlockStoragePolicyProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct StorageUuidsProto <: ProtoType
-    storageUuids::Base.Vector{AbstractString}
-    StorageUuidsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct StorageUuidsProto
 
 mutable struct LocatedBlockProto <: ProtoType
     b::ExtendedBlockProto
@@ -325,10 +344,12 @@ mutable struct FsServerDefaultsProto <: ProtoType
     encryptDataTransfer::Bool
     trashInterval::UInt64
     checksumType::Int32
+    keyProviderUri::AbstractString
+    policyId::UInt32
     FsServerDefaultsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FsServerDefaultsProto
 const __req_FsServerDefaultsProto = Symbol[:blockSize,:bytesPerChecksum,:writePacketSize,:replication,:fileBufferSize]
-const __val_FsServerDefaultsProto = Dict(:encryptDataTransfer => false, :trashInterval => 0, :checksumType => ChecksumTypeProto.CHECKSUM_CRC32)
+const __val_FsServerDefaultsProto = Dict(:encryptDataTransfer => false, :trashInterval => 0, :checksumType => ChecksumTypeProto.CHECKSUM_CRC32, :policyId => 0)
 meta(t::Type{FsServerDefaultsProto}) = meta(t, __req_FsServerDefaultsProto, ProtoBuf.DEF_FNUM, __val_FsServerDefaultsProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct DirectoryListingProto <: ProtoType
@@ -373,69 +394,6 @@ end #mutable struct SnapshotDiffReportProto
 const __req_SnapshotDiffReportProto = Symbol[:snapshotRoot,:fromSnapshot,:toSnapshot]
 meta(t::Type{SnapshotDiffReportProto}) = meta(t, __req_SnapshotDiffReportProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-mutable struct StorageInfoProto <: ProtoType
-    layoutVersion::UInt32
-    namespceID::UInt32
-    clusterID::AbstractString
-    cTime::UInt64
-    StorageInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct StorageInfoProto
-const __req_StorageInfoProto = Symbol[:layoutVersion,:namespceID,:clusterID,:cTime]
-meta(t::Type{StorageInfoProto}) = meta(t, __req_StorageInfoProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-struct __enum_NamenodeRegistrationProto_NamenodeRoleProto <: ProtoEnum
-    NAMENODE::Int32
-    BACKUP::Int32
-    CHECKPOINT::Int32
-    __enum_NamenodeRegistrationProto_NamenodeRoleProto() = new(1,2,3)
-end #struct __enum_NamenodeRegistrationProto_NamenodeRoleProto
-const NamenodeRegistrationProto_NamenodeRoleProto = __enum_NamenodeRegistrationProto_NamenodeRoleProto()
-
-mutable struct NamenodeRegistrationProto <: ProtoType
-    rpcAddress::AbstractString
-    httpAddress::AbstractString
-    storageInfo::StorageInfoProto
-    role::Int32
-    NamenodeRegistrationProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct NamenodeRegistrationProto
-const __req_NamenodeRegistrationProto = Symbol[:rpcAddress,:httpAddress,:storageInfo]
-const __val_NamenodeRegistrationProto = Dict(:role => NamenodeRegistrationProto_NamenodeRoleProto.NAMENODE)
-meta(t::Type{NamenodeRegistrationProto}) = meta(t, __req_NamenodeRegistrationProto, ProtoBuf.DEF_FNUM, __val_NamenodeRegistrationProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct CheckpointSignatureProto <: ProtoType
-    blockPoolId::AbstractString
-    mostRecentCheckpointTxId::UInt64
-    curSegmentTxId::UInt64
-    storageInfo::StorageInfoProto
-    CheckpointSignatureProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct CheckpointSignatureProto
-const __req_CheckpointSignatureProto = Symbol[:blockPoolId,:mostRecentCheckpointTxId,:curSegmentTxId,:storageInfo]
-meta(t::Type{CheckpointSignatureProto}) = meta(t, __req_CheckpointSignatureProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct CheckpointCommandProto <: ProtoType
-    signature::CheckpointSignatureProto
-    needToReturnImage::Bool
-    CheckpointCommandProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct CheckpointCommandProto
-const __req_CheckpointCommandProto = Symbol[:signature,:needToReturnImage]
-meta(t::Type{CheckpointCommandProto}) = meta(t, __req_CheckpointCommandProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-struct __enum_NamenodeCommandProto_Type <: ProtoEnum
-    NamenodeCommand::Int32
-    CheckPointCommand::Int32
-    __enum_NamenodeCommandProto_Type() = new(0,1)
-end #struct __enum_NamenodeCommandProto_Type
-const NamenodeCommandProto_Type = __enum_NamenodeCommandProto_Type()
-
-mutable struct NamenodeCommandProto <: ProtoType
-    action::UInt32
-    _type::Int32
-    checkpointCmd::CheckpointCommandProto
-    NamenodeCommandProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct NamenodeCommandProto
-const __req_NamenodeCommandProto = Symbol[:action,:_type]
-meta(t::Type{NamenodeCommandProto}) = meta(t, __req_NamenodeCommandProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
 mutable struct BlockProto <: ProtoType
     blockId::UInt64
     genStamp::UInt64
@@ -445,89 +403,6 @@ end #mutable struct BlockProto
 const __req_BlockProto = Symbol[:blockId,:genStamp]
 const __val_BlockProto = Dict(:numBytes => 0)
 meta(t::Type{BlockProto}) = meta(t, __req_BlockProto, ProtoBuf.DEF_FNUM, __val_BlockProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct BlockWithLocationsProto <: ProtoType
-    block::BlockProto
-    datanodeUuids::Base.Vector{AbstractString}
-    storageUuids::Base.Vector{AbstractString}
-    storageTypes::Base.Vector{Int32}
-    BlockWithLocationsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct BlockWithLocationsProto
-const __req_BlockWithLocationsProto = Symbol[:block]
-meta(t::Type{BlockWithLocationsProto}) = meta(t, __req_BlockWithLocationsProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct BlocksWithLocationsProto <: ProtoType
-    blocks::Base.Vector{BlockWithLocationsProto}
-    BlocksWithLocationsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct BlocksWithLocationsProto
-
-mutable struct RemoteEditLogProto <: ProtoType
-    startTxId::UInt64
-    endTxId::UInt64
-    isInProgress::Bool
-    RemoteEditLogProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct RemoteEditLogProto
-const __req_RemoteEditLogProto = Symbol[:startTxId,:endTxId]
-const __val_RemoteEditLogProto = Dict(:isInProgress => false)
-meta(t::Type{RemoteEditLogProto}) = meta(t, __req_RemoteEditLogProto, ProtoBuf.DEF_FNUM, __val_RemoteEditLogProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct RemoteEditLogManifestProto <: ProtoType
-    logs::Base.Vector{RemoteEditLogProto}
-    RemoteEditLogManifestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct RemoteEditLogManifestProto
-
-mutable struct NamespaceInfoProto <: ProtoType
-    buildVersion::AbstractString
-    unused::UInt32
-    blockPoolID::AbstractString
-    storageInfo::StorageInfoProto
-    softwareVersion::AbstractString
-    capabilities::UInt64
-    NamespaceInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct NamespaceInfoProto
-const __req_NamespaceInfoProto = Symbol[:buildVersion,:unused,:blockPoolID,:storageInfo,:softwareVersion]
-const __val_NamespaceInfoProto = Dict(:capabilities => 0)
-meta(t::Type{NamespaceInfoProto}) = meta(t, __req_NamespaceInfoProto, ProtoBuf.DEF_FNUM, __val_NamespaceInfoProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct BlockKeyProto <: ProtoType
-    keyId::UInt32
-    expiryDate::UInt64
-    keyBytes::Array{UInt8,1}
-    BlockKeyProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct BlockKeyProto
-const __req_BlockKeyProto = Symbol[:keyId,:expiryDate]
-meta(t::Type{BlockKeyProto}) = meta(t, __req_BlockKeyProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct ExportedBlockKeysProto <: ProtoType
-    isBlockTokenEnabled::Bool
-    keyUpdateInterval::UInt64
-    tokenLifeTime::UInt64
-    currentKey::BlockKeyProto
-    allKeys::Base.Vector{BlockKeyProto}
-    ExportedBlockKeysProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ExportedBlockKeysProto
-const __req_ExportedBlockKeysProto = Symbol[:isBlockTokenEnabled,:keyUpdateInterval,:tokenLifeTime,:currentKey]
-meta(t::Type{ExportedBlockKeysProto}) = meta(t, __req_ExportedBlockKeysProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct RecoveringBlockProto <: ProtoType
-    newGenStamp::UInt64
-    block::LocatedBlockProto
-    truncateBlock::BlockProto
-    RecoveringBlockProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct RecoveringBlockProto
-const __req_RecoveringBlockProto = Symbol[:newGenStamp,:block]
-meta(t::Type{RecoveringBlockProto}) = meta(t, __req_RecoveringBlockProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
-
-mutable struct VersionRequestProto <: ProtoType
-    VersionRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct VersionRequestProto
-
-mutable struct VersionResponseProto <: ProtoType
-    info::NamespaceInfoProto
-    VersionResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct VersionResponseProto
-const __req_VersionResponseProto = Symbol[:info]
-meta(t::Type{VersionResponseProto}) = meta(t, __req_VersionResponseProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct SnapshotInfoProto <: ProtoType
     snapshotName::AbstractString
@@ -550,4 +425,4 @@ const __req_RollingUpgradeStatusProto = Symbol[:blockPoolId]
 const __val_RollingUpgradeStatusProto = Dict(:finalized => false)
 meta(t::Type{RollingUpgradeStatusProto}) = meta(t, __req_RollingUpgradeStatusProto, ProtoBuf.DEF_FNUM, __val_RollingUpgradeStatusProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export StorageTypeProto, CipherSuiteProto, CryptoProtocolVersionProto, ChecksumTypeProto, ReplicaStateProto, ExtendedBlockProto, DatanodeIDProto, DatanodeLocalInfoProto, DatanodeInfosProto, DatanodeInfoProto_AdminState, DatanodeInfoProto, DatanodeStorageProto_StorageState, DatanodeStorageProto, StorageReportProto, ContentSummaryProto, StorageTypeQuotaInfosProto, StorageTypeQuotaInfoProto, CorruptFileBlocksProto, FsPermissionProto, StorageTypesProto, BlockStoragePolicyProto, StorageUuidsProto, LocatedBlockProto, DataEncryptionKeyProto, FileEncryptionInfoProto, PerFileEncryptionInfoProto, ZoneEncryptionInfoProto, CipherOptionProto, LocatedBlocksProto, HdfsFileStatusProto_FileType, HdfsFileStatusProto, FsServerDefaultsProto, DirectoryListingProto, SnapshottableDirectoryStatusProto, SnapshottableDirectoryListingProto, SnapshotDiffReportEntryProto, SnapshotDiffReportProto, StorageInfoProto, NamenodeRegistrationProto_NamenodeRoleProto, NamenodeRegistrationProto, CheckpointSignatureProto, NamenodeCommandProto_Type, NamenodeCommandProto, CheckpointCommandProto, BlockProto, BlockWithLocationsProto, BlocksWithLocationsProto, RemoteEditLogProto, RemoteEditLogManifestProto, NamespaceInfoProto, BlockKeyProto, ExportedBlockKeysProto, RecoveringBlockProto, VersionRequestProto, VersionResponseProto, SnapshotInfoProto, RollingUpgradeStatusProto
+export StorageTypeProto, CipherSuiteProto, CryptoProtocolVersionProto, ChecksumTypeProto, ExtendedBlockProto, DatanodeIDProto, DatanodeLocalInfoProto, DatanodeVolumeInfoProto, DatanodeInfosProto, DatanodeInfoProto_AdminState, DatanodeInfoProto, DatanodeStorageProto_StorageState, DatanodeStorageProto, StorageReportProto, ContentSummaryProto, QuotaUsageProto, StorageTypeQuotaInfosProto, StorageTypeQuotaInfoProto, CorruptFileBlocksProto, FsPermissionProto, StorageTypesProto, BlockStoragePolicyProto, LocatedBlockProto, DataEncryptionKeyProto, FileEncryptionInfoProto, PerFileEncryptionInfoProto, ZoneEncryptionInfoProto, CipherOptionProto, LocatedBlocksProto, HdfsFileStatusProto_FileType, HdfsFileStatusProto, FsServerDefaultsProto, DirectoryListingProto, SnapshottableDirectoryStatusProto, SnapshottableDirectoryListingProto, SnapshotDiffReportEntryProto, SnapshotDiffReportProto, BlockProto, SnapshotInfoProto, RollingUpgradeStatusProto

--- a/src/hadoop/inotify_pb.jl
+++ b/src/hadoop/inotify_pb.jl
@@ -9,7 +9,8 @@ struct __enum_EventType <: ProtoEnum
     EVENT_RENAME::Int32
     EVENT_METADATA::Int32
     EVENT_UNLINK::Int32
-    __enum_EventType() = new(0,1,2,3,4,5)
+    EVENT_TRUNCATE::Int32
+    __enum_EventType() = new(0,1,2,3,4,5,6)
 end #struct __enum_EventType
 const EventType = __enum_EventType()
 
@@ -74,6 +75,15 @@ end #mutable struct CloseEventProto
 const __req_CloseEventProto = Symbol[:path,:fileSize,:timestamp]
 meta(t::Type{CloseEventProto}) = meta(t, __req_CloseEventProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
+mutable struct TruncateEventProto <: ProtoType
+    path::AbstractString
+    fileSize::Int64
+    timestamp::Int64
+    TruncateEventProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct TruncateEventProto
+const __req_TruncateEventProto = Symbol[:path,:fileSize,:timestamp]
+meta(t::Type{TruncateEventProto}) = meta(t, __req_TruncateEventProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct AppendEventProto <: ProtoType
     path::AbstractString
     newBlock::Bool
@@ -128,4 +138,4 @@ end #mutable struct EventsListProto
 const __req_EventsListProto = Symbol[:firstTxid,:lastTxid,:syncTxid]
 meta(t::Type{EventsListProto}) = meta(t, __req_EventsListProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export EventType, INodeType, MetadataUpdateType, EventProto, EventBatchProto, CreateEventProto, CloseEventProto, AppendEventProto, RenameEventProto, MetadataUpdateEventProto, UnlinkEventProto, EventsListProto
+export EventType, INodeType, MetadataUpdateType, EventProto, EventBatchProto, CreateEventProto, CloseEventProto, TruncateEventProto, AppendEventProto, RenameEventProto, MetadataUpdateEventProto, UnlinkEventProto, EventsListProto

--- a/src/hadoop/xattr_pb.jl
+++ b/src/hadoop/xattr_pb.jl
@@ -28,12 +28,6 @@ end #mutable struct XAttrProto
 const __req_XAttrProto = Symbol[:namespace,:name]
 meta(t::Type{XAttrProto}) = meta(t, __req_XAttrProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-mutable struct XAttrEditLogProto <: ProtoType
-    src::AbstractString
-    xAttrs::Base.Vector{XAttrProto}
-    XAttrEditLogProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct XAttrEditLogProto
-
 mutable struct SetXAttrRequestProto <: ProtoType
     src::AbstractString
     xAttr::XAttrProto
@@ -84,4 +78,4 @@ mutable struct RemoveXAttrResponseProto <: ProtoType
     RemoveXAttrResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RemoveXAttrResponseProto
 
-export XAttrSetFlagProto, XAttrProto_XAttrNamespaceProto, XAttrProto, XAttrEditLogProto, SetXAttrRequestProto, SetXAttrResponseProto, GetXAttrsRequestProto, GetXAttrsResponseProto, ListXAttrsRequestProto, ListXAttrsResponseProto, RemoveXAttrRequestProto, RemoveXAttrResponseProto
+export XAttrSetFlagProto, XAttrProto_XAttrNamespaceProto, XAttrProto, SetXAttrRequestProto, SetXAttrResponseProto, GetXAttrsRequestProto, GetXAttrsResponseProto, ListXAttrsRequestProto, ListXAttrsResponseProto, RemoveXAttrRequestProto, RemoveXAttrResponseProto

--- a/src/hadoop/yarn_protos_pb.jl
+++ b/src/hadoop/yarn_protos_pb.jl
@@ -3,6 +3,12 @@ using ProtoBuf
 import ProtoBuf.meta
 import ..hadoop
 
+struct __enum_ResourceTypesProto <: ProtoEnum
+    COUNTABLE::Int32
+    __enum_ResourceTypesProto() = new(0)
+end #struct __enum_ResourceTypesProto
+const ResourceTypesProto = __enum_ResourceTypesProto()
+
 struct __enum_ContainerStateProto <: ProtoEnum
     C_NEW::Int32
     C_RUNNING::Int32
@@ -10,6 +16,16 @@ struct __enum_ContainerStateProto <: ProtoEnum
     __enum_ContainerStateProto() = new(1,2,3)
 end #struct __enum_ContainerStateProto
 const ContainerStateProto = __enum_ContainerStateProto()
+
+struct __enum_ContainerSubStateProto <: ProtoEnum
+    CSS_SCHEDULED::Int32
+    CSS_RUNNING::Int32
+    CSS_PAUSED::Int32
+    CSS_COMPLETING::Int32
+    CSS_DONE::Int32
+    __enum_ContainerSubStateProto() = new(1,2,3,4,5)
+end #struct __enum_ContainerSubStateProto
+const ContainerSubStateProto = __enum_ContainerSubStateProto()
 
 struct __enum_YarnApplicationStateProto <: ProtoEnum
     NEW::Int32
@@ -45,7 +61,8 @@ struct __enum_FinalApplicationStatusProto <: ProtoEnum
     APP_SUCCEEDED::Int32
     APP_FAILED::Int32
     APP_KILLED::Int32
-    __enum_FinalApplicationStatusProto() = new(0,1,2,3)
+    APP_ENDED::Int32
+    __enum_FinalApplicationStatusProto() = new(0,1,2,3,4)
 end #struct __enum_FinalApplicationStatusProto
 const FinalApplicationStatusProto = __enum_FinalApplicationStatusProto()
 
@@ -65,6 +82,18 @@ struct __enum_LocalResourceTypeProto <: ProtoEnum
 end #struct __enum_LocalResourceTypeProto
 const LocalResourceTypeProto = __enum_LocalResourceTypeProto()
 
+struct __enum_LogAggregationStatusProto <: ProtoEnum
+    LOG_DISABLED::Int32
+    LOG_NOT_START::Int32
+    LOG_RUNNING::Int32
+    LOG_SUCCEEDED::Int32
+    LOG_FAILED::Int32
+    LOG_TIME_OUT::Int32
+    LOG_RUNNING_WITH_FAILURE::Int32
+    __enum_LogAggregationStatusProto() = new(1,2,3,4,5,6,7)
+end #struct __enum_LogAggregationStatusProto
+const LogAggregationStatusProto = __enum_LogAggregationStatusProto()
+
 struct __enum_NodeStateProto <: ProtoEnum
     NS_NEW::Int32
     NS_RUNNING::Int32
@@ -72,9 +101,25 @@ struct __enum_NodeStateProto <: ProtoEnum
     NS_DECOMMISSIONED::Int32
     NS_LOST::Int32
     NS_REBOOTED::Int32
-    __enum_NodeStateProto() = new(1,2,3,4,5,6)
+    NS_DECOMMISSIONING::Int32
+    NS_SHUTDOWN::Int32
+    __enum_NodeStateProto() = new(1,2,3,4,5,6,7,8)
 end #struct __enum_NodeStateProto
 const NodeStateProto = __enum_NodeStateProto()
+
+struct __enum_ContainerTypeProto <: ProtoEnum
+    APPLICATION_MASTER::Int32
+    TASK::Int32
+    __enum_ContainerTypeProto() = new(1,2)
+end #struct __enum_ContainerTypeProto
+const ContainerTypeProto = __enum_ContainerTypeProto()
+
+struct __enum_ExecutionTypeProto <: ProtoEnum
+    GUARANTEED::Int32
+    OPPORTUNISTIC::Int32
+    __enum_ExecutionTypeProto() = new(1,2)
+end #struct __enum_ExecutionTypeProto
+const ExecutionTypeProto = __enum_ExecutionTypeProto()
 
 struct __enum_AMCommandProto <: ProtoEnum
     AM_RESYNC::Int32
@@ -82,6 +127,12 @@ struct __enum_AMCommandProto <: ProtoEnum
     __enum_AMCommandProto() = new(1,2)
 end #struct __enum_AMCommandProto
 const AMCommandProto = __enum_AMCommandProto()
+
+struct __enum_ApplicationTimeoutTypeProto <: ProtoEnum
+    APP_TIMEOUT_LIFETIME::Int32
+    __enum_ApplicationTimeoutTypeProto() = new(1)
+end #struct __enum_ApplicationTimeoutTypeProto
+const ApplicationTimeoutTypeProto = __enum_ApplicationTimeoutTypeProto()
 
 struct __enum_ApplicationAccessTypeProto <: ProtoEnum
     APPACCESS_VIEW_APP::Int32
@@ -93,7 +144,8 @@ const ApplicationAccessTypeProto = __enum_ApplicationAccessTypeProto()
 struct __enum_QueueStateProto <: ProtoEnum
     Q_STOPPED::Int32
     Q_RUNNING::Int32
-    __enum_QueueStateProto() = new(1,2)
+    Q_DRAINING::Int32
+    __enum_QueueStateProto() = new(1,2,3)
 end #struct __enum_QueueStateProto
 const QueueStateProto = __enum_QueueStateProto()
 
@@ -103,6 +155,14 @@ struct __enum_QueueACLProto <: ProtoEnum
     __enum_QueueACLProto() = new(1,2)
 end #struct __enum_QueueACLProto
 const QueueACLProto = __enum_QueueACLProto()
+
+struct __enum_SignalContainerCommandProto <: ProtoEnum
+    OUTPUT_THREAD_DUMP::Int32
+    GRACEFUL_SHUTDOWN::Int32
+    FORCEFUL_SHUTDOWN::Int32
+    __enum_SignalContainerCommandProto() = new(1,2,3)
+end #struct __enum_SignalContainerCommandProto
+const SignalContainerCommandProto = __enum_SignalContainerCommandProto()
 
 struct __enum_ReservationRequestInterpreterProto <: ProtoEnum
     R_ANY::Int32
@@ -121,6 +181,14 @@ struct __enum_ContainerExitStatusProto <: ProtoEnum
     __enum_ContainerExitStatusProto() = new(0,-1000,-100,-101)
 end #struct __enum_ContainerExitStatusProto
 const ContainerExitStatusProto = __enum_ContainerExitStatusProto()
+
+struct __enum_ContainerRetryPolicyProto <: ProtoEnum
+    NEVER_RETRY::Int32
+    RETRY_ON_ALL_ERRORS::Int32
+    RETRY_ON_SPECIFIC_ERROR_CODES::Int32
+    __enum_ContainerRetryPolicyProto() = new(0,1,2)
+end #struct __enum_ContainerRetryPolicyProto
+const ContainerRetryPolicyProto = __enum_ContainerRetryPolicyProto()
 
 mutable struct SerializedExceptionProto <: ProtoType
     message::AbstractString
@@ -149,11 +217,38 @@ mutable struct ContainerIdProto <: ProtoType
     ContainerIdProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ContainerIdProto
 
+mutable struct ResourceInformationProto <: ProtoType
+    key::AbstractString
+    value::Int64
+    units::AbstractString
+    _type::Int32
+    ResourceInformationProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceInformationProto
+const __req_ResourceInformationProto = Symbol[:key]
+meta(t::Type{ResourceInformationProto}) = meta(t, __req_ResourceInformationProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ResourceTypeInfoProto <: ProtoType
+    name::AbstractString
+    units::AbstractString
+    _type::Int32
+    ResourceTypeInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceTypeInfoProto
+const __req_ResourceTypeInfoProto = Symbol[:name]
+meta(t::Type{ResourceTypeInfoProto}) = meta(t, __req_ResourceTypeInfoProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct ResourceProto <: ProtoType
-    memory::Int32
+    memory::Int64
     virtual_cores::Int32
+    resource_value_map::Base.Vector{ResourceInformationProto}
     ResourceProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ResourceProto
+
+mutable struct ResourceUtilizationProto <: ProtoType
+    pmem::Int32
+    vmem::Int32
+    cpu::Float32
+    ResourceUtilizationProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceUtilizationProto
 
 mutable struct ResourceOptionProto <: ProtoType
     resource::ResourceProto
@@ -186,6 +281,14 @@ mutable struct LocalResourceProto <: ProtoType
     LocalResourceProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct LocalResourceProto
 
+mutable struct StringLongMapProto <: ProtoType
+    key::AbstractString
+    value::Int64
+    StringLongMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct StringLongMapProto
+const __req_StringLongMapProto = Symbol[:key,:value]
+meta(t::Type{StringLongMapProto}) = meta(t, __req_StringLongMapProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct ApplicationResourceUsageReportProto <: ProtoType
     num_used_containers::Int32
     num_reserved_containers::Int32
@@ -194,8 +297,29 @@ mutable struct ApplicationResourceUsageReportProto <: ProtoType
     needed_resources::ResourceProto
     memory_seconds::Int64
     vcore_seconds::Int64
+    queue_usage_percentage::Float32
+    cluster_usage_percentage::Float32
+    preempted_memory_seconds::Int64
+    preempted_vcore_seconds::Int64
+    application_resource_usage_map::Base.Vector{StringLongMapProto}
+    application_preempted_resource_usage_map::Base.Vector{StringLongMapProto}
     ApplicationResourceUsageReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ApplicationResourceUsageReportProto
+
+mutable struct ApplicationTimeoutProto <: ProtoType
+    application_timeout_type::Int32
+    expire_time::AbstractString
+    remaining_time::Int64
+    ApplicationTimeoutProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ApplicationTimeoutProto
+const __req_ApplicationTimeoutProto = Symbol[:application_timeout_type]
+meta(t::Type{ApplicationTimeoutProto}) = meta(t, __req_ApplicationTimeoutProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct AppTimeoutsMapProto <: ProtoType
+    application_timeout_type::Int32
+    application_timeout::ApplicationTimeoutProto
+    AppTimeoutsMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct AppTimeoutsMapProto
 
 mutable struct ApplicationReportProto <: ProtoType
     applicationId::ApplicationIdProto
@@ -218,9 +342,17 @@ mutable struct ApplicationReportProto <: ProtoType
     applicationType::AbstractString
     am_rm_token::hadoop.common.TokenProto
     applicationTags::Base.Vector{AbstractString}
+    log_aggregation_status::Int32
+    unmanaged_application::Bool
+    priority::PriorityProto
+    appNodeLabelExpression::AbstractString
+    amNodeLabelExpression::AbstractString
+    appTimeouts::Base.Vector{AppTimeoutsMapProto}
+    launchTime::Int64
+    submitTime::Int64
     ApplicationReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ApplicationReportProto
-const __val_ApplicationReportProto = Dict(:diagnostics => "N/A")
+const __val_ApplicationReportProto = Dict(:diagnostics => "N/A", :unmanaged_application => false)
 meta(t::Type{ApplicationReportProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ApplicationReportProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct ApplicationAttemptReportProto <: ProtoType
@@ -232,6 +364,8 @@ mutable struct ApplicationAttemptReportProto <: ProtoType
     yarn_application_attempt_state::Int32
     am_container_id::ContainerIdProto
     original_tracking_url::AbstractString
+    startTime::Int64
+    finishTime::Int64
     ApplicationAttemptReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ApplicationAttemptReportProto
 const __val_ApplicationAttemptReportProto = Dict(:diagnostics => "N/A")
@@ -261,9 +395,10 @@ mutable struct ContainerReportProto <: ProtoType
     container_exit_status::Int32
     container_state::Int32
     node_http_address::AbstractString
+    executionType::Int32
     ContainerReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ContainerReportProto
-const __val_ContainerReportProto = Dict(:diagnostics_info => "N/A")
+const __val_ContainerReportProto = Dict(:diagnostics_info => "N/A", :executionType => ExecutionTypeProto.GUARANTEED)
 meta(t::Type{ContainerReportProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ContainerReportProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct ContainerProto <: ProtoType
@@ -273,8 +408,13 @@ mutable struct ContainerProto <: ProtoType
     resource::ResourceProto
     priority::PriorityProto
     container_token::hadoop.common.TokenProto
+    execution_type::Int32
+    allocation_request_id::Int64
+    version::Int32
     ContainerProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ContainerProto
+const __val_ContainerProto = Dict(:execution_type => ExecutionTypeProto.GUARANTEED, :allocation_request_id => -1, :version => 0)
+meta(t::Type{ContainerProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ContainerProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct NodeReportProto <: ProtoType
     nodeId::NodeIdProto
@@ -287,6 +427,8 @@ mutable struct NodeReportProto <: ProtoType
     health_report::AbstractString
     last_health_report_time::Int64
     node_labels::Base.Vector{AbstractString}
+    containers_utilization::ResourceUtilizationProto
+    node_utilization::ResourceUtilizationProto
     NodeReportProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct NodeReportProto
 
@@ -302,6 +444,30 @@ mutable struct LabelsToNodeIdsProto <: ProtoType
     LabelsToNodeIdsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct LabelsToNodeIdsProto
 
+mutable struct NodeLabelProto <: ProtoType
+    name::AbstractString
+    isExclusive::Bool
+    NodeLabelProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct NodeLabelProto
+const __val_NodeLabelProto = Dict(:isExclusive => true)
+meta(t::Type{NodeLabelProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_NodeLabelProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct AMBlackListingRequestProto <: ProtoType
+    blacklisting_enabled::Bool
+    blacklisting_failure_threshold::Float32
+    AMBlackListingRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct AMBlackListingRequestProto
+const __val_AMBlackListingRequestProto = Dict(:blacklisting_enabled => false)
+meta(t::Type{AMBlackListingRequestProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_AMBlackListingRequestProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ExecutionTypeRequestProto <: ProtoType
+    execution_type::Int32
+    enforce_execution_type::Bool
+    ExecutionTypeRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ExecutionTypeRequestProto
+const __val_ExecutionTypeRequestProto = Dict(:execution_type => ExecutionTypeProto.GUARANTEED, :enforce_execution_type => false)
+meta(t::Type{ExecutionTypeRequestProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ExecutionTypeRequestProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct ResourceRequestProto <: ProtoType
     priority::PriorityProto
     resource_name::AbstractString
@@ -309,9 +475,11 @@ mutable struct ResourceRequestProto <: ProtoType
     num_containers::Int32
     relax_locality::Bool
     node_label_expression::AbstractString
+    execution_type_request::ExecutionTypeRequestProto
+    allocation_request_id::Int64
     ResourceRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ResourceRequestProto
-const __val_ResourceRequestProto = Dict(:relax_locality => true)
+const __val_ResourceRequestProto = Dict(:relax_locality => true, :allocation_request_id => 0)
 meta(t::Type{ResourceRequestProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ResourceRequestProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct PreemptionContainerProto <: ProtoType
@@ -347,11 +515,25 @@ mutable struct ResourceBlacklistRequestProto <: ProtoType
     ResourceBlacklistRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ResourceBlacklistRequestProto
 
+mutable struct ApplicationTimeoutMapProto <: ProtoType
+    application_timeout_type::Int32
+    timeout::Int64
+    ApplicationTimeoutMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ApplicationTimeoutMapProto
+
+mutable struct ApplicationUpdateTimeoutMapProto <: ProtoType
+    application_timeout_type::Int32
+    expire_time::AbstractString
+    ApplicationUpdateTimeoutMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ApplicationUpdateTimeoutMapProto
+
 mutable struct LogAggregationContextProto <: ProtoType
     include_pattern::AbstractString
     exclude_pattern::AbstractString
     rolled_logs_include_pattern::AbstractString
     rolled_logs_exclude_pattern::AbstractString
+    log_aggregation_policy_class_name::AbstractString
+    log_aggregation_policy_parameters::AbstractString
     LogAggregationContextProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct LogAggregationContextProto
 const __val_LogAggregationContextProto = Dict(:include_pattern => ".*", :rolled_logs_exclude_pattern => ".*")
@@ -367,8 +549,52 @@ meta(t::Type{ApplicationACLMapProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_F
 
 mutable struct YarnClusterMetricsProto <: ProtoType
     num_node_managers::Int32
+    num_decommissioned_nms::Int32
+    num_active_nms::Int32
+    num_lost_nms::Int32
+    num_unhealthy_nms::Int32
+    num_rebooted_nms::Int32
     YarnClusterMetricsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct YarnClusterMetricsProto
+
+mutable struct QueueStatisticsProto <: ProtoType
+    numAppsSubmitted::Int64
+    numAppsRunning::Int64
+    numAppsPending::Int64
+    numAppsCompleted::Int64
+    numAppsKilled::Int64
+    numAppsFailed::Int64
+    numActiveUsers::Int64
+    availableMemoryMB::Int64
+    allocatedMemoryMB::Int64
+    pendingMemoryMB::Int64
+    reservedMemoryMB::Int64
+    availableVCores::Int64
+    allocatedVCores::Int64
+    pendingVCores::Int64
+    reservedVCores::Int64
+    allocatedContainers::Int64
+    pendingContainers::Int64
+    reservedContainers::Int64
+    QueueStatisticsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct QueueStatisticsProto
+
+mutable struct QueueConfigurationsProto <: ProtoType
+    capacity::Float32
+    absoluteCapacity::Float32
+    maxCapacity::Float32
+    absoluteMaxCapacity::Float32
+    maxAMPercentage::Float32
+    QueueConfigurationsProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct QueueConfigurationsProto
+
+mutable struct QueueConfigurationsMapProto <: ProtoType
+    partitionName::AbstractString
+    queueConfigurations::QueueConfigurationsProto
+    QueueConfigurationsMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct QueueConfigurationsMapProto
+const __req_QueueConfigurationsMapProto = Symbol[:partitionName]
+meta(t::Type{QueueConfigurationsMapProto}) = meta(t, __req_QueueConfigurationsMapProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct QueueInfoProto <: ProtoType
     queueName::AbstractString
@@ -380,6 +606,10 @@ mutable struct QueueInfoProto <: ProtoType
     applications::Base.Vector{ApplicationReportProto}
     accessibleNodeLabels::Base.Vector{AbstractString}
     defaultNodeLabelExpression::AbstractString
+    queueStatistics::QueueStatisticsProto
+    preemptionDisabled::Bool
+    queueConfigurationsMap::Base.Vector{QueueConfigurationsMapProto}
+    intraQueuePreemptionDisabled::Bool
     QueueInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct QueueInfoProto
 
@@ -418,37 +648,41 @@ mutable struct ReservationDefinitionProto <: ProtoType
     arrival::Int64
     deadline::Int64
     reservation_name::AbstractString
+    recurrence_expression::AbstractString
+    priority::PriorityProto
     ReservationDefinitionProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ReservationDefinitionProto
+const __val_ReservationDefinitionProto = Dict(:recurrence_expression => "0")
+meta(t::Type{ReservationDefinitionProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ReservationDefinitionProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-mutable struct ContainerStatusProto <: ProtoType
-    container_id::ContainerIdProto
-    state::Int32
-    diagnostics::AbstractString
-    exit_status::Int32
-    ContainerStatusProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ContainerStatusProto
-const __val_ContainerStatusProto = Dict(:diagnostics => "N/A", :exit_status => -1000)
-meta(t::Type{ContainerStatusProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ContainerStatusProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+mutable struct ResourceAllocationRequestProto <: ProtoType
+    start_time::Int64
+    end_time::Int64
+    resource::ResourceProto
+    ResourceAllocationRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceAllocationRequestProto
 
-mutable struct ContainerResourceIncreaseRequestProto <: ProtoType
-    container_id::ContainerIdProto
-    capability::ResourceProto
-    ContainerResourceIncreaseRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ContainerResourceIncreaseRequestProto
+mutable struct ReservationAllocationStateProto <: ProtoType
+    reservation_definition::ReservationDefinitionProto
+    allocation_requests::Base.Vector{ResourceAllocationRequestProto}
+    start_time::Int64
+    end_time::Int64
+    user::AbstractString
+    contains_gangs::Bool
+    acceptance_time::Int64
+    reservation_id::ReservationIdProto
+    ReservationAllocationStateProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ReservationAllocationStateProto
 
-mutable struct ContainerResourceIncreaseProto <: ProtoType
-    container_id::ContainerIdProto
-    capability::ResourceProto
-    container_token::hadoop.common.TokenProto
-    ContainerResourceIncreaseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ContainerResourceIncreaseProto
-
-mutable struct ContainerResourceDecreaseProto <: ProtoType
-    container_id::ContainerIdProto
-    capability::ResourceProto
-    ContainerResourceDecreaseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ContainerResourceDecreaseProto
+mutable struct ContainerRetryContextProto <: ProtoType
+    retry_policy::Int32
+    error_codes::Base.Vector{Int32}
+    max_retries::Int32
+    retry_interval::Int32
+    ContainerRetryContextProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerRetryContextProto
+const __val_ContainerRetryContextProto = Dict(:retry_policy => ContainerRetryPolicyProto.NEVER_RETRY, :max_retries => 0, :retry_interval => 0)
+meta(t::Type{ContainerRetryContextProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ContainerRetryContextProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct StringLocalResourceMapProto <: ProtoType
     key::AbstractString
@@ -461,6 +695,20 @@ mutable struct StringStringMapProto <: ProtoType
     value::AbstractString
     StringStringMapProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct StringStringMapProto
+
+mutable struct ContainerStatusProto <: ProtoType
+    container_id::ContainerIdProto
+    state::Int32
+    diagnostics::AbstractString
+    exit_status::Int32
+    capability::ResourceProto
+    executionType::Int32
+    container_attributes::Base.Vector{StringStringMapProto}
+    container_sub_state::Int32
+    ContainerStatusProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerStatusProto
+const __val_ContainerStatusProto = Dict(:diagnostics => "N/A", :exit_status => -1000, :executionType => ExecutionTypeProto.GUARANTEED)
+meta(t::Type{ContainerStatusProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ContainerStatusProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct StringBytesMapProto <: ProtoType
     key::AbstractString
@@ -475,6 +723,8 @@ mutable struct ContainerLaunchContextProto <: ProtoType
     environment::Base.Vector{StringStringMapProto}
     command::Base.Vector{AbstractString}
     application_ACLs::Base.Vector{ApplicationACLMapProto}
+    container_retry_context::ContainerRetryContextProto
+    tokens_conf::Array{UInt8,1}
     ContainerLaunchContextProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ContainerLaunchContextProto
 
@@ -495,10 +745,36 @@ mutable struct ApplicationSubmissionContextProto <: ProtoType
     log_aggregation_context::LogAggregationContextProto
     reservation_id::ReservationIdProto
     node_label_expression::AbstractString
-    am_container_resource_request::ResourceRequestProto
+    am_container_resource_request::Base.Vector{ResourceRequestProto}
+    application_timeouts::Base.Vector{ApplicationTimeoutMapProto}
     ApplicationSubmissionContextProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ApplicationSubmissionContextProto
 const __val_ApplicationSubmissionContextProto = Dict(:application_name => "N/A", :queue => "default", :cancel_tokens_when_complete => true, :unmanaged_am => false, :maxAppAttempts => 0, :applicationType => "YARN", :keep_containers_across_application_attempts => false, :attempt_failures_validity_interval => -1)
 meta(t::Type{ApplicationSubmissionContextProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ApplicationSubmissionContextProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export ContainerStateProto, YarnApplicationStateProto, YarnApplicationAttemptStateProto, FinalApplicationStatusProto, LocalResourceVisibilityProto, LocalResourceTypeProto, NodeStateProto, AMCommandProto, ApplicationAccessTypeProto, QueueStateProto, QueueACLProto, ReservationRequestInterpreterProto, ContainerExitStatusProto, SerializedExceptionProto, ApplicationIdProto, ApplicationAttemptIdProto, ContainerIdProto, ResourceProto, ResourceOptionProto, NodeResourceMapProto, PriorityProto, ContainerProto, ContainerReportProto, URLProto, LocalResourceProto, ApplicationResourceUsageReportProto, ApplicationReportProto, ApplicationAttemptReportProto, NodeIdProto, NodeReportProto, NodeIdToLabelsProto, LabelsToNodeIdsProto, ResourceRequestProto, PreemptionMessageProto, StrictPreemptionContractProto, PreemptionContractProto, PreemptionContainerProto, PreemptionResourceRequestProto, ResourceBlacklistRequestProto, ApplicationSubmissionContextProto, LogAggregationContextProto, ApplicationACLMapProto, YarnClusterMetricsProto, QueueInfoProto, QueueUserACLInfoProto, ReservationIdProto, ReservationRequestProto, ReservationRequestsProto, ReservationDefinitionProto, ContainerLaunchContextProto, ContainerStatusProto, ContainerResourceIncreaseRequestProto, ContainerResourceIncreaseProto, ContainerResourceDecreaseProto, StringLocalResourceMapProto, StringStringMapProto, StringBytesMapProto
+mutable struct ContainerResourceIncreaseRequestProto <: ProtoType
+    container_id::ContainerIdProto
+    capability::ResourceProto
+    ContainerResourceIncreaseRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerResourceIncreaseRequestProto
+
+mutable struct ContainerResourceIncreaseProto <: ProtoType
+    container_id::ContainerIdProto
+    capability::ResourceProto
+    container_token::hadoop.common.TokenProto
+    ContainerResourceIncreaseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerResourceIncreaseProto
+
+mutable struct ContainerResourceDecreaseProto <: ProtoType
+    container_id::ContainerIdProto
+    capability::ResourceProto
+    ContainerResourceDecreaseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerResourceDecreaseProto
+
+mutable struct CollectorInfoProto <: ProtoType
+    collector_addr::AbstractString
+    collector_token::hadoop.common.TokenProto
+    CollectorInfoProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct CollectorInfoProto
+
+export ResourceTypesProto, ContainerStateProto, ContainerSubStateProto, YarnApplicationStateProto, YarnApplicationAttemptStateProto, FinalApplicationStatusProto, LocalResourceVisibilityProto, LocalResourceTypeProto, LogAggregationStatusProto, NodeStateProto, ContainerTypeProto, ExecutionTypeProto, AMCommandProto, ApplicationTimeoutTypeProto, ApplicationAccessTypeProto, QueueStateProto, QueueACLProto, SignalContainerCommandProto, ReservationRequestInterpreterProto, ContainerExitStatusProto, ContainerRetryPolicyProto, SerializedExceptionProto, ApplicationIdProto, ApplicationAttemptIdProto, ContainerIdProto, ResourceInformationProto, ResourceTypeInfoProto, ResourceProto, ResourceUtilizationProto, ResourceOptionProto, NodeResourceMapProto, PriorityProto, ContainerProto, ContainerReportProto, URLProto, LocalResourceProto, StringLongMapProto, ApplicationResourceUsageReportProto, ApplicationReportProto, AppTimeoutsMapProto, ApplicationTimeoutProto, ApplicationAttemptReportProto, NodeIdProto, NodeReportProto, NodeIdToLabelsProto, LabelsToNodeIdsProto, NodeLabelProto, AMBlackListingRequestProto, ResourceRequestProto, ExecutionTypeRequestProto, PreemptionMessageProto, StrictPreemptionContractProto, PreemptionContractProto, PreemptionContainerProto, PreemptionResourceRequestProto, ResourceBlacklistRequestProto, ApplicationSubmissionContextProto, ApplicationTimeoutMapProto, ApplicationUpdateTimeoutMapProto, LogAggregationContextProto, ApplicationACLMapProto, YarnClusterMetricsProto, QueueStatisticsProto, QueueInfoProto, QueueConfigurationsProto, QueueConfigurationsMapProto, QueueUserACLInfoProto, ReservationIdProto, ReservationRequestProto, ReservationRequestsProto, ReservationDefinitionProto, ResourceAllocationRequestProto, ReservationAllocationStateProto, ContainerLaunchContextProto, ContainerStatusProto, ContainerRetryContextProto, StringLocalResourceMapProto, StringStringMapProto, StringBytesMapProto, ContainerResourceIncreaseRequestProto, ContainerResourceIncreaseProto, ContainerResourceDecreaseProto, CollectorInfoProto

--- a/src/hadoop/yarn_service_protos_pb.jl
+++ b/src/hadoop/yarn_service_protos_pb.jl
@@ -3,6 +3,15 @@ using ProtoBuf
 import ProtoBuf.meta
 import ..hadoop
 
+struct __enum_ContainerUpdateTypeProto <: ProtoEnum
+    INCREASE_RESOURCE::Int32
+    DECREASE_RESOURCE::Int32
+    PROMOTE_EXECUTION_TYPE::Int32
+    DEMOTE_EXECUTION_TYPE::Int32
+    __enum_ContainerUpdateTypeProto() = new(0,1,2,3)
+end #struct __enum_ContainerUpdateTypeProto
+const ContainerUpdateTypeProto = __enum_ContainerUpdateTypeProto()
+
 struct __enum_SchedulerResourceTypes <: ProtoEnum
     MEMORY::Int32
     CPU::Int32
@@ -39,6 +48,24 @@ end #mutable struct FinishApplicationMasterResponseProto
 const __val_FinishApplicationMasterResponseProto = Dict(:isUnregistered => false)
 meta(t::Type{FinishApplicationMasterResponseProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_FinishApplicationMasterResponseProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
+mutable struct UpdateContainerRequestProto <: ProtoType
+    container_version::Int32
+    container_id::ContainerIdProto
+    update_type::Int32
+    capability::ResourceProto
+    execution_type::Int32
+    UpdateContainerRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateContainerRequestProto
+const __req_UpdateContainerRequestProto = Symbol[:container_version,:container_id,:update_type]
+meta(t::Type{UpdateContainerRequestProto}) = meta(t, __req_UpdateContainerRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct UpdateContainerErrorProto <: ProtoType
+    reason::AbstractString
+    update_request::UpdateContainerRequestProto
+    current_container_version::Int32
+    UpdateContainerErrorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateContainerErrorProto
+
 mutable struct AllocateRequestProto <: ProtoType
     ask::Base.Vector{ResourceRequestProto}
     release::Base.Vector{ContainerIdProto}
@@ -46,8 +73,12 @@ mutable struct AllocateRequestProto <: ProtoType
     response_id::Int32
     progress::Float32
     increase_request::Base.Vector{ContainerResourceIncreaseRequestProto}
+    update_requests::Base.Vector{UpdateContainerRequestProto}
+    tracking_url::AbstractString
     AllocateRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct AllocateRequestProto
+const __fnum_AllocateRequestProto = Int[1,2,3,4,5,6,7,11]
+meta(t::Type{AllocateRequestProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_AllocateRequestProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct NMTokenProto <: ProtoType
     nodeId::NodeIdProto
@@ -66,6 +97,14 @@ mutable struct RegisterApplicationMasterResponseProto <: ProtoType
     RegisterApplicationMasterResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RegisterApplicationMasterResponseProto
 
+mutable struct UpdatedContainerProto <: ProtoType
+    update_type::Int32
+    container::ContainerProto
+    UpdatedContainerProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdatedContainerProto
+const __req_UpdatedContainerProto = Symbol[:update_type,:container]
+meta(t::Type{UpdatedContainerProto}) = meta(t, __req_UpdatedContainerProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
 mutable struct AllocateResponseProto <: ProtoType
     a_m_command::Int32
     response_id::Int32
@@ -79,6 +118,10 @@ mutable struct AllocateResponseProto <: ProtoType
     increased_containers::Base.Vector{ContainerResourceIncreaseProto}
     decreased_containers::Base.Vector{ContainerResourceDecreaseProto}
     am_rm_token::hadoop.common.TokenProto
+    application_priority::PriorityProto
+    collector_info::CollectorInfoProto
+    update_errors::Base.Vector{UpdateContainerErrorProto}
+    updated_containers::Base.Vector{UpdatedContainerProto}
     AllocateResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct AllocateResponseProto
 
@@ -111,8 +154,18 @@ mutable struct SubmitApplicationResponseProto <: ProtoType
     SubmitApplicationResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct SubmitApplicationResponseProto
 
+mutable struct FailApplicationAttemptRequestProto <: ProtoType
+    application_attempt_id::ApplicationAttemptIdProto
+    FailApplicationAttemptRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct FailApplicationAttemptRequestProto
+
+mutable struct FailApplicationAttemptResponseProto <: ProtoType
+    FailApplicationAttemptResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct FailApplicationAttemptResponseProto
+
 mutable struct KillApplicationRequestProto <: ProtoType
     application_id::ApplicationIdProto
+    diagnostics::AbstractString
     KillApplicationRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct KillApplicationRequestProto
 
@@ -222,9 +275,57 @@ mutable struct GetClusterNodeLabelsRequestProto <: ProtoType
 end #mutable struct GetClusterNodeLabelsRequestProto
 
 mutable struct GetClusterNodeLabelsResponseProto <: ProtoType
-    nodeLabels::Base.Vector{AbstractString}
+    deprecatedNodeLabels::Base.Vector{AbstractString}
+    nodeLabels::Base.Vector{NodeLabelProto}
     GetClusterNodeLabelsResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GetClusterNodeLabelsResponseProto
+
+mutable struct UpdateApplicationPriorityRequestProto <: ProtoType
+    applicationId::ApplicationIdProto
+    applicationPriority::PriorityProto
+    UpdateApplicationPriorityRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateApplicationPriorityRequestProto
+const __req_UpdateApplicationPriorityRequestProto = Symbol[:applicationId,:applicationPriority]
+meta(t::Type{UpdateApplicationPriorityRequestProto}) = meta(t, __req_UpdateApplicationPriorityRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct UpdateApplicationPriorityResponseProto <: ProtoType
+    applicationPriority::PriorityProto
+    UpdateApplicationPriorityResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateApplicationPriorityResponseProto
+
+mutable struct SignalContainerRequestProto <: ProtoType
+    container_id::ContainerIdProto
+    command::Int32
+    SignalContainerRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct SignalContainerRequestProto
+const __req_SignalContainerRequestProto = Symbol[:container_id,:command]
+meta(t::Type{SignalContainerRequestProto}) = meta(t, __req_SignalContainerRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct SignalContainerResponseProto <: ProtoType
+    SignalContainerResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct SignalContainerResponseProto
+
+mutable struct UpdateApplicationTimeoutsRequestProto <: ProtoType
+    applicationId::ApplicationIdProto
+    application_timeouts::Base.Vector{ApplicationUpdateTimeoutMapProto}
+    UpdateApplicationTimeoutsRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateApplicationTimeoutsRequestProto
+const __req_UpdateApplicationTimeoutsRequestProto = Symbol[:applicationId]
+meta(t::Type{UpdateApplicationTimeoutsRequestProto}) = meta(t, __req_UpdateApplicationTimeoutsRequestProto, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct UpdateApplicationTimeoutsResponseProto <: ProtoType
+    application_timeouts::Base.Vector{ApplicationUpdateTimeoutMapProto}
+    UpdateApplicationTimeoutsResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct UpdateApplicationTimeoutsResponseProto
+
+mutable struct GetAllResourceTypeInfoRequestProto <: ProtoType
+    GetAllResourceTypeInfoRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetAllResourceTypeInfoRequestProto
+
+mutable struct GetAllResourceTypeInfoResponseProto <: ProtoType
+    resource_type_info::Base.Vector{ResourceTypeInfoProto}
+    GetAllResourceTypeInfoResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetAllResourceTypeInfoResponseProto
 
 mutable struct StartContainerRequestProto <: ProtoType
     container_launch_context::ContainerLaunchContextProto
@@ -246,15 +347,40 @@ mutable struct StopContainerResponseProto <: ProtoType
     StopContainerResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct StopContainerResponseProto
 
-mutable struct GetContainerStatusRequestProto <: ProtoType
+mutable struct ResourceLocalizationRequestProto <: ProtoType
     container_id::ContainerIdProto
-    GetContainerStatusRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct GetContainerStatusRequestProto
+    local_resources::Base.Vector{StringLocalResourceMapProto}
+    ResourceLocalizationRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceLocalizationRequestProto
 
-mutable struct GetContainerStatusResponseProto <: ProtoType
-    status::ContainerStatusProto
-    GetContainerStatusResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct GetContainerStatusResponseProto
+mutable struct ResourceLocalizationResponseProto <: ProtoType
+    ResourceLocalizationResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ResourceLocalizationResponseProto
+
+mutable struct ReInitializeContainerRequestProto <: ProtoType
+    container_id::ContainerIdProto
+    container_launch_context::ContainerLaunchContextProto
+    auto_commit::Bool
+    ReInitializeContainerRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ReInitializeContainerRequestProto
+const __val_ReInitializeContainerRequestProto = Dict(:auto_commit => true)
+meta(t::Type{ReInitializeContainerRequestProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_ReInitializeContainerRequestProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ReInitializeContainerResponseProto <: ProtoType
+    ReInitializeContainerResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ReInitializeContainerResponseProto
+
+mutable struct RestartContainerResponseProto <: ProtoType
+    RestartContainerResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct RestartContainerResponseProto
+
+mutable struct RollbackResponseProto <: ProtoType
+    RollbackResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct RollbackResponseProto
+
+mutable struct CommitResponseProto <: ProtoType
+    CommitResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct CommitResponseProto
 
 mutable struct StartContainersRequestProto <: ProtoType
     start_container_request::Base.Vector{StartContainerRequestProto}
@@ -295,6 +421,28 @@ mutable struct GetContainerStatusesResponseProto <: ProtoType
     failed_requests::Base.Vector{ContainerExceptionMapProto}
     GetContainerStatusesResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GetContainerStatusesResponseProto
+
+mutable struct IncreaseContainersResourceRequestProto <: ProtoType
+    increase_containers::Base.Vector{hadoop.common.TokenProto}
+    IncreaseContainersResourceRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct IncreaseContainersResourceRequestProto
+
+mutable struct IncreaseContainersResourceResponseProto <: ProtoType
+    succeeded_requests::Base.Vector{ContainerIdProto}
+    failed_requests::Base.Vector{ContainerExceptionMapProto}
+    IncreaseContainersResourceResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct IncreaseContainersResourceResponseProto
+
+mutable struct ContainerUpdateRequestProto <: ProtoType
+    update_container_token::Base.Vector{hadoop.common.TokenProto}
+    ContainerUpdateRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerUpdateRequestProto
+
+mutable struct ContainerUpdateResponseProto <: ProtoType
+    succeeded_requests::Base.Vector{ContainerIdProto}
+    failed_requests::Base.Vector{ContainerExceptionMapProto}
+    ContainerUpdateResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ContainerUpdateResponseProto
 
 mutable struct GetApplicationAttemptReportRequestProto <: ProtoType
     application_attempt_id::ApplicationAttemptIdProto
@@ -357,14 +505,23 @@ mutable struct ReleaseSharedCacheResourceResponseProto <: ProtoType
     ReleaseSharedCacheResourceResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ReleaseSharedCacheResourceResponseProto
 
+mutable struct GetNewReservationRequestProto <: ProtoType
+    GetNewReservationRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetNewReservationRequestProto
+
+mutable struct GetNewReservationResponseProto <: ProtoType
+    reservation_id::ReservationIdProto
+    GetNewReservationResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct GetNewReservationResponseProto
+
 mutable struct ReservationSubmissionRequestProto <: ProtoType
     queue::AbstractString
     reservation_definition::ReservationDefinitionProto
+    reservation_id::ReservationIdProto
     ReservationSubmissionRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ReservationSubmissionRequestProto
 
 mutable struct ReservationSubmissionResponseProto <: ProtoType
-    reservation_id::ReservationIdProto
     ReservationSubmissionResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ReservationSubmissionResponseProto
 
@@ -387,6 +544,22 @@ mutable struct ReservationDeleteResponseProto <: ProtoType
     ReservationDeleteResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ReservationDeleteResponseProto
 
+mutable struct ReservationListRequestProto <: ProtoType
+    queue::AbstractString
+    reservation_id::AbstractString
+    start_time::Int64
+    end_time::Int64
+    include_resource_allocations::Bool
+    ReservationListRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ReservationListRequestProto
+const __fnum_ReservationListRequestProto = Int[1,3,4,5,6]
+meta(t::Type{ReservationListRequestProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ReservationListRequestProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ReservationListResponseProto <: ProtoType
+    reservations::Base.Vector{ReservationAllocationStateProto}
+    ReservationListResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ReservationListResponseProto
+
 mutable struct RunSharedCacheCleanerTaskRequestProto <: ProtoType
     RunSharedCacheCleanerTaskRequestProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RunSharedCacheCleanerTaskRequestProto
@@ -396,4 +569,4 @@ mutable struct RunSharedCacheCleanerTaskResponseProto <: ProtoType
     RunSharedCacheCleanerTaskResponseProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct RunSharedCacheCleanerTaskResponseProto
 
-export SchedulerResourceTypes, ApplicationsRequestScopeProto, RegisterApplicationMasterRequestProto, RegisterApplicationMasterResponseProto, FinishApplicationMasterRequestProto, FinishApplicationMasterResponseProto, AllocateRequestProto, NMTokenProto, AllocateResponseProto, GetNewApplicationRequestProto, GetNewApplicationResponseProto, GetApplicationReportRequestProto, GetApplicationReportResponseProto, SubmitApplicationRequestProto, SubmitApplicationResponseProto, KillApplicationRequestProto, KillApplicationResponseProto, GetClusterMetricsRequestProto, GetClusterMetricsResponseProto, MoveApplicationAcrossQueuesRequestProto, MoveApplicationAcrossQueuesResponseProto, GetApplicationsRequestProto, GetApplicationsResponseProto, GetClusterNodesRequestProto, GetClusterNodesResponseProto, GetQueueInfoRequestProto, GetQueueInfoResponseProto, GetQueueUserAclsInfoRequestProto, GetQueueUserAclsInfoResponseProto, GetNodesToLabelsRequestProto, GetNodesToLabelsResponseProto, GetLabelsToNodesRequestProto, GetLabelsToNodesResponseProto, GetClusterNodeLabelsRequestProto, GetClusterNodeLabelsResponseProto, StartContainerRequestProto, StartContainerResponseProto, StopContainerRequestProto, StopContainerResponseProto, GetContainerStatusRequestProto, GetContainerStatusResponseProto, StartContainersRequestProto, ContainerExceptionMapProto, StartContainersResponseProto, StopContainersRequestProto, StopContainersResponseProto, GetContainerStatusesRequestProto, GetContainerStatusesResponseProto, GetApplicationAttemptReportRequestProto, GetApplicationAttemptReportResponseProto, GetApplicationAttemptsRequestProto, GetApplicationAttemptsResponseProto, GetContainerReportRequestProto, GetContainerReportResponseProto, GetContainersRequestProto, GetContainersResponseProto, UseSharedCacheResourceRequestProto, UseSharedCacheResourceResponseProto, ReleaseSharedCacheResourceRequestProto, ReleaseSharedCacheResourceResponseProto, ReservationSubmissionRequestProto, ReservationSubmissionResponseProto, ReservationUpdateRequestProto, ReservationUpdateResponseProto, ReservationDeleteRequestProto, ReservationDeleteResponseProto, RunSharedCacheCleanerTaskRequestProto, RunSharedCacheCleanerTaskResponseProto
+export ContainerUpdateTypeProto, SchedulerResourceTypes, ApplicationsRequestScopeProto, RegisterApplicationMasterRequestProto, RegisterApplicationMasterResponseProto, FinishApplicationMasterRequestProto, FinishApplicationMasterResponseProto, UpdateContainerRequestProto, UpdateContainerErrorProto, AllocateRequestProto, NMTokenProto, UpdatedContainerProto, AllocateResponseProto, GetNewApplicationRequestProto, GetNewApplicationResponseProto, GetApplicationReportRequestProto, GetApplicationReportResponseProto, SubmitApplicationRequestProto, SubmitApplicationResponseProto, FailApplicationAttemptRequestProto, FailApplicationAttemptResponseProto, KillApplicationRequestProto, KillApplicationResponseProto, GetClusterMetricsRequestProto, GetClusterMetricsResponseProto, MoveApplicationAcrossQueuesRequestProto, MoveApplicationAcrossQueuesResponseProto, GetApplicationsRequestProto, GetApplicationsResponseProto, GetClusterNodesRequestProto, GetClusterNodesResponseProto, GetQueueInfoRequestProto, GetQueueInfoResponseProto, GetQueueUserAclsInfoRequestProto, GetQueueUserAclsInfoResponseProto, GetNodesToLabelsRequestProto, GetNodesToLabelsResponseProto, GetLabelsToNodesRequestProto, GetLabelsToNodesResponseProto, GetClusterNodeLabelsRequestProto, GetClusterNodeLabelsResponseProto, UpdateApplicationPriorityRequestProto, UpdateApplicationPriorityResponseProto, SignalContainerRequestProto, SignalContainerResponseProto, UpdateApplicationTimeoutsRequestProto, UpdateApplicationTimeoutsResponseProto, GetAllResourceTypeInfoRequestProto, GetAllResourceTypeInfoResponseProto, StartContainerRequestProto, StartContainerResponseProto, StopContainerRequestProto, StopContainerResponseProto, ResourceLocalizationRequestProto, ResourceLocalizationResponseProto, ReInitializeContainerRequestProto, ReInitializeContainerResponseProto, RestartContainerResponseProto, RollbackResponseProto, CommitResponseProto, StartContainersRequestProto, ContainerExceptionMapProto, StartContainersResponseProto, StopContainersRequestProto, StopContainersResponseProto, GetContainerStatusesRequestProto, GetContainerStatusesResponseProto, IncreaseContainersResourceRequestProto, IncreaseContainersResourceResponseProto, ContainerUpdateRequestProto, ContainerUpdateResponseProto, GetApplicationAttemptReportRequestProto, GetApplicationAttemptReportResponseProto, GetApplicationAttemptsRequestProto, GetApplicationAttemptsResponseProto, GetContainerReportRequestProto, GetContainerReportResponseProto, GetContainersRequestProto, GetContainersResponseProto, UseSharedCacheResourceRequestProto, UseSharedCacheResourceResponseProto, ReleaseSharedCacheResourceRequestProto, ReleaseSharedCacheResourceResponseProto, GetNewReservationRequestProto, GetNewReservationResponseProto, ReservationSubmissionRequestProto, ReservationSubmissionResponseProto, ReservationUpdateRequestProto, ReservationUpdateResponseProto, ReservationDeleteRequestProto, ReservationDeleteResponseProto, ReservationListRequestProto, ReservationListResponseProto, RunSharedCacheCleanerTaskRequestProto, RunSharedCacheCleanerTaskResponseProto

--- a/src/rpc.jl
+++ b/src/rpc.jl
@@ -250,9 +250,10 @@ function recv_rpc_message(channel::HadoopRpcChannel, resp)
 
         resp_hdr = RpcResponseHeaderProto()
         readproto(IOBuffer(hdr_bytes), resp_hdr)
+        @debug("resp_hdr", resp_hdr)
 
-        (resp_hdr.callId == reinterpret(UInt32, channel.sent_call_id)) || throw(HadoopRpcException("unknown callid. received:$(resp_hdr.callId) sent:$(channel.sent_call_id). status: $(resp_hdr.status)"))
         (resp_hdr.status == RpcResponseHeaderProto_RpcStatusProto.SUCCESS) || throw(HadoopRpcException(resp_hdr))
+        (resp_hdr.callId == reinterpret(UInt32, channel.sent_call_id)) || throw(HadoopRpcException("unknown callid. received:$(resp_hdr.callId) sent:$(channel.sent_call_id). status: $(resp_hdr.status)"))
 
         if resp_hdr.status == RpcResponseHeaderProto_RpcStatusProto.SUCCESS
             hdr_len = UInt32(length(hdr_bytes))

--- a/src/ugi.jl
+++ b/src/ugi.jl
@@ -12,7 +12,7 @@ end
 add_token(ugi::UserGroupInformation, token::TokenProto) = add_token(ugi, token.service, token)
 add_token(ugi::UserGroupInformation, alias::AbstractString, token::TokenProto) = (ugi.tokens[alias] = token; nothing)
 
-username(userinfo::UserInformationProto) = isfilled(userinfo, :realUser) ? userinfo.realUser : userInfo.effectiveUser
+username(userinfo::UserInformationProto) = isfilled(userinfo, :realUser) ? userinfo.realUser : userinfo.effectiveUser
 username(ugi::UserGroupInformation) = username(ugi.userinfo)
 
 function find_tokens(ugi::UserGroupInformation; alias::AbstractString="", kind::AbstractString="")


### PR DESCRIPTION
Update the protocol implementation to Hadoop 2.10 specifications.
It should be backward compatible to previous used version (2.7).

Also added some fixes:
- Yarn appmaster response_id must begin with 0, and we need to send back the same response_id that was sent back from the server
- typo while accessing field in ugi
- check uninitialized fields in YarnAppMaster show (fixes #43)