### PR TITLE
allow both realUser and effectiveUser optionally

### DIFF
--- a/src/api_hdfs_base.jl
+++ b/src/api_hdfs_base.jl
@@ -62,10 +62,13 @@ struct HDFSFile
     path::AbstractString
 end
 
-function HDFSFile(uristr::AbstractString)
+function HDFSFile(uristr::AbstractString; ugi::Union{UserGroupInformation,Nothing}=nothing, proxy::Bool=false)
     uri = URI(uristr)
     (uri.scheme == "hdfs") || throw(HDFSException("Not a HDFS URI: $uristr"))
-    client = HDFSClient(uri.host, uri.port, UserGroupInformation(uri.userinfo))
+    if ugi === nothing
+        ugi = isempty(uri.userinfo) ? UserGroupInformation() : UserGroupInformation(uri.userinfo)
+    end
+    client = HDFSClient(uri.host, uri.port, ugi)
     HDFSFile(client, uri.path)
 end
 

--- a/src/cluster_manager.jl
+++ b/src/cluster_manager.jl
@@ -119,6 +119,7 @@ function launch(manager::YarnManager, params::Dict, instances_arr::Array, c::Con
     cookie = ":cookie_" * cluster_cookie()
     initargs = "using Elly; Elly.setup_worker($(ipaddr.host), $(port), $(cookie))"
     clc = launchcontext(cmd="$cmd -e '$initargs'", env=appenv)
+    # TODO: do we need to add tokens into clc?
 
     @debug("YarnManager launch", initargs, context=clc)
     on_alloc = (cid) -> container_start(manager.am, cid, clc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,6 @@
 include("hdfstests.jl")
 include("yarntests.jl")
 
+test_ugi()
 test_hdfs()
 test_yarn()


### PR DESCRIPTION
Allow caller to set both realUser and effectiveUser optionally (proxied user scenario).