### PR TITLE
improve api and cluster manager, update docs

### DIFF
--- a/HDFS.md
+++ b/HDFS.md
@@ -25,6 +25,9 @@ The DFS can be navigated using the same Julia APIs as used for a traditional fil
 julia> pwd(dfs)
 "/"
 
+julia> du(dfs)
+0x0000000000000017
+
 julia> readdir(dfs)
 5-element Array{AbstractString,1}:
  "testdir" 
@@ -65,6 +68,28 @@ HDFSFileInfo: bar
 
 julia> isfile(bar_file)
 true
+
+julia> isdir(bar_file)
+false
+
+julia> islink(bar_file)
+false
+
+julia> filemode(bar_file)
+0x000001a4
+
+julia> mtime(bar_file)
+0x0000016f7f71aa30
+
+julia> atime(bar_file)
+0x0000016f7f71a980
+
+julia> dirname(bar_file)
+HDFSFile: hdfs://userid@localhost:9000/tmp/foo/
+
+julia> joinpath(dirname(bar_file), "baz_file")
+HDFSFile: hdfs://userid@localhost:9000/tmp/foo/baz_file
+
 ...
 ````
 
@@ -90,13 +115,24 @@ HDFSFileInfo: baz.txt
 julia> open(bar_file, "w") do f
            write(f, b"hello world")
        end
-0x000000000000000b
+11
 
 julia> open(bar_file, "r") do f
-           bytes = Array(UInt8, filesize(f))
+           bytes = Vector{UInt8}(undef, filesize(f))
            read!(f, bytes)
-           println(bytestring(bytes))
+           println(String(bytes))
        end
 hello world
 ````
+
+Elly also supports block level access to files, to enable distributed processing.
+
+```
+julia> hdfs_blocks(huge_file)
+1-element Array{Tuple{UInt64,Array},1}:
+ (0x0000000000000000, AbstractString["node1"])
+ (0x0000000007d00000, AbstractString["node2"])
+ (0x000000000fa00000, AbstractString["node3"])
+
+```
 

--- a/src/Elly.jl
+++ b/src/Elly.jl
@@ -42,9 +42,6 @@ export YarnAppMaster, register, unregister, kill, can_schedule_mem, can_schedule
 
 export YarnManager, launch, manage
 
-const Lock = Channel
-makelock() = Channel{Int}(1)
-
 include("hadoop/hadoop.jl")
 using Elly.hadoop
 using Elly.hadoop.common

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -111,7 +111,7 @@ callback(yam::YarnAppMaster, on_container_alloc::Union{Nothing,Function}, on_con
 function submit(client::YarnClient, unmanagedappmaster::YarnAppMaster)
     @debug("submitting unmanaged application")
     clc = launchcontext()
-    app = submit(client, clc, YARN_CONTAINER_MEM_DEFAULT, YARN_CONTAINER_CPU_DEFAULT; unmanaged=true)
+    app = submit(client, clc; unmanaged=true)
 
     # keep the am_rm token
     tok = am_rm_token(app)

--- a/src/api_yarn_appmaster.jl
+++ b/src/api_yarn_appmaster.jl
@@ -171,7 +171,8 @@ kill(yam::YarnAppMaster, diagnostics::AbstractString="") = _unregister(yam, Fina
 container_allocate(yam::YarnAppMaster, numcontainers::Int; opts...) = request_alloc(yam.containers, numcontainers; opts...)
 container_release(yam::YarnAppMaster, cids::ContainerIdProto...) = request_release(yam.containers, cids...)
 
-container_start(yam::YarnAppMaster, cid::ContainerIdProto, container_spec::ContainerLaunchContextProto) = container_start(yam, yam.containers.containers[cid], container_spec)
+container_start(yam::YarnAppMaster, cid::ContainerIdProto, container_spec::ContainerLaunchContextProto) = container_start(yam, container_id_string(cid), container_spec)
+container_start(yam::YarnAppMaster, cidstr::String, container_spec::ContainerLaunchContextProto) = container_start(yam, yam.containers.containers[cidstr], container_spec)
 function container_start(yam::YarnAppMaster, container::ContainerProto, container_spec::ContainerLaunchContextProto)
     @debug("starting", container)
     req = StartContainerRequestProto(container_launch_context=container_spec, container_token=container.container_token)
@@ -197,7 +198,8 @@ function container_start(yam::YarnAppMaster, container::ContainerProto, containe
     cid
 end
 
-container_stop(yam::YarnAppMaster, cid::ContainerIdProto) = container_stop(yam, yam.containers.containers[cid])
+container_stop(yam::YarnAppMaster, cid::ContainerIdProto) = container_stop(yam, container_id_string(cid))
+container_stop(yam::YarnAppMaster, cidstr::String) = container_stop(yam, yam.containers.containers[cidstr])
 function container_stop(yam::YarnAppMaster, container::ContainerProto)
     @debug("stopping", container)
 

--- a/src/api_yarn_client.jl
+++ b/src/api_yarn_client.jl
@@ -173,12 +173,12 @@ function _new_app(client::YarnClient)
     resp.application_id, resp.maximumCapability.memory, resp.maximumCapability.virtual_cores
 end
 
-function submit(client::YarnClient, cmd::Union{AbstractString,Vector}, mem::Integer=YARN_CONTAINER_MEM_DEFAULT, cores::Integer=YARN_CONTAINER_CPU_DEFAULT, env::Dict{String,String}=Dict{String,String}(); kwargs...)
+function submit(client::YarnClient, cmd::Union{AbstractString,Vector}, env::Dict{String,String}=Dict{String,String}(); kwargs...)
     container_spec = launchcontext(cmd=cmd, env=env)
-    submit(client, container_spec, mem, cores; kwargs...)
+    submit(client, container_spec; kwargs...)
 end
 
-function submit(client::YarnClient, container_spec::ContainerLaunchContextProto, mem::Integer=YARN_CONTAINER_MEM_DEFAULT, cores::Integer=YARN_CONTAINER_CPU_DEFAULT;
+function submit(client::YarnClient, container_spec::ContainerLaunchContextProto; mem::Integer=YARN_CONTAINER_MEM_DEFAULT, cores::Integer=YARN_CONTAINER_CPU_DEFAULT,
         priority::Int32=one(Int32), appname::AbstractString="EllyApp", queue::AbstractString="default", apptype::AbstractString="YARN", 
         reuse::Bool=false, unmanaged::Bool=false, schedaddr::String="")
     @debug("submitting application", unmanaged=unmanaged, cmd=container_spec.command)

--- a/src/containerid.jl
+++ b/src/containerid.jl
@@ -35,3 +35,19 @@ function parse_container_id(cidstr::String)
     attemptid_proto = ApplicationAttemptIdProto(; application_id=appid_proto, attemptId=attemptid)
     ContainerIdProto(; app_id=appid_proto, app_attempt_id=attemptid_proto, id=cid)
 end
+
+function container_id_string(cid::ContainerIdProto)
+    app_id = isdefined(cid, :app_id) ? cid.app_id : cid.app_attempt_id.application_id
+    attempt_id = isdefined(cid, :app_attempt_id) ? cid.app_attempt_id.attemptId : 0
+    id = cid.id
+    epoch = id >> 40
+    id = CONTAINER_ID_BITMASK & id
+
+    parts = [CONTAINER_PREFIX]
+    (epoch > 0) && push!(parts, EPOCH_PREFIX * lpad(epoch, 2, "0"))
+    push!(parts, string(app_id.cluster_timestamp))
+    push!(parts, lpad(app_id.id, 4, "0"))
+    push!(parts, lpad(attempt_id, 2, "0"))
+    push!(parts, lpad(id, 6, "0"))
+    join(parts, CONTAINER_ID_SPLITTER)
+end

--- a/test/yarntests.jl
+++ b/test/yarntests.jl
@@ -15,17 +15,29 @@ end
 
 function test_container_id()
     @info("testing container ids")
-    cid = Elly.parse_container_id("container_1577681661884_0005_01_000001")
+    cidstr = "container_1577681661884_0005_01_000001"
+    cid = Elly.parse_container_id(cidstr)
     @test cid.id == 1
     @test cid.app_id.cluster_timestamp == 1577681661884
     @test cid.app_id.id == 5
     @test cid.app_attempt_id.attemptId == 1
+    @test Elly.container_id_string(cid) == cidstr
 
-    cid = Elly.parse_container_id("container_e17_1410901177871_0001_01_000005")
+    cidstr = "container_e17_1410901177871_0001_01_000005"
+    cid = Elly.parse_container_id(cidstr)
     @test cid.id == 18691697672197
     @test cid.app_id.cluster_timestamp == 1410901177871
     @test cid.app_id.id == 1
     @test cid.app_attempt_id.attemptId == 1
+    @test Elly.container_id_string(cid) == cidstr
+
+    cidstr = "container_e03_1465095377475_0007_02_000001"
+    cid = Elly.parse_container_id(cidstr)
+    @test cid.id == 3298534883329
+    @test cid.app_id.cluster_timestamp == 1465095377475
+    @test cid.app_id.id == 7
+    @test cid.app_attempt_id.attemptId == 2
+    @test Elly.container_id_string(cid) == cidstr
 
     nothing
 end

--- a/test/yarntests.jl
+++ b/test/yarntests.jl
@@ -93,7 +93,7 @@ function test_managed_yarn_clustermanager(host="localhost", rmport=8032, schedpo
     @info("starting managed julia with environment", env)
 
     testscript = joinpath(@__DIR__, "yarnmanagedcm.jl")
-    app = submit(clnt, [Elly._currprocname(), testscript], Elly.YARN_CONTAINER_MEM_DEFAULT, Elly.YARN_CONTAINER_CPU_DEFAULT, env; schedaddr="$(host):$(schedport)")
+    app = submit(clnt, [Elly._currprocname(), testscript], env; schedaddr="$(host):$(schedport)")
     Elly.wait_for_state(app, Elly.YarnApplicationStateProto.FINISHED)
     @info("app complete", status=status(app))
     @test isfile("/tmp/ellytest.log")

--- a/test/yarntests.jl
+++ b/test/yarntests.jl
@@ -60,8 +60,7 @@ function make_julia_env()
         end
     end
     if !("JULIA_LOAD_PATH" in keys(env))
-        home = ENV["HOME"]
-        env["JULIA_LOAD_PATH"] = join(Base.LOAD_PATH, ':') * ":$(home)/.julia/dev:$(home)/.julia/packages"
+        env["JULIA_LOAD_PATH"] = join([Base.LOAD_PATH..., joinpath(Base.homedir(), ".julia", "dev"), joinpath(Base.homedir(), ".julia", "packages")], ':')
     end
     if !("JULIA_DEPOT_PATH" in keys(env))
         env["JULIA_DEPOT_PATH"] = join(Base.DEPOT_PATH, ':')
@@ -84,6 +83,7 @@ function test_yarn_clustermanager(yarncm::YarnManager, limitedtestenv::Bool)
     @everywhere println("hi")
     rmprocs(workers())
     @test nprocs() == 1
+    @test yarncm.am.registration !== nothing # because keep_connected is true by default
     nothing
 end
 


### PR DESCRIPTION
- make mem and cpu spec optional for yarn submit
- handle interrupt, finalize and deregister of workers
- release yarn containers and resources on worker termination
- update docs